### PR TITLE
feat: implement advanced search and filtering for policy listing

### DIFF
--- a/src/components/policies/listing/AdvancedFilterPanel.tsx
+++ b/src/components/policies/listing/AdvancedFilterPanel.tsx
@@ -1,0 +1,424 @@
+"use client";
+
+import React, { useState, useCallback, useEffect, useRef } from "react";
+import {
+  Search,
+  X,
+  ChevronDown,
+  Filter,
+  SlidersHorizontal,
+} from "lucide-react";
+import {
+  PolicyFilterState,
+  CoverageType,
+  ProviderId,
+} from "@/types/policies/filter";
+import {
+  ALL_COVERAGE_TYPES,
+  COVERAGE_TYPE_LABELS,
+  ALL_PROVIDERS,
+  PROVIDER_LABELS,
+} from "@/types/policies/filter";
+
+interface AdvancedFilterPanelProps {
+  filterState: PolicyFilterState;
+  activeFilterCount: number;
+  onSearchChange: (query: string) => void;
+  onCoverageTypeToggle: (type: CoverageType) => void;
+  onProviderToggle: (provider: ProviderId) => void;
+  onPremiumRangeChange: (range: { min: number; max: number }) => void;
+  onDeductibleRangeChange: (range: { min: number; max: number }) => void;
+  onClearAll: () => void;
+}
+
+interface RangeSliderProps {
+  min: number;
+  max: number;
+  value: { min: number; max: number };
+  onChange: (value: { min: number; max: number }) => void;
+  minLabel: string;
+  maxLabel?: string;
+  step?: number;
+  formatValue?: (value: number) => string;
+}
+
+function RangeSlider({
+  min,
+  max,
+  value,
+  onChange,
+  minLabel,
+  maxLabel,
+  step = 10,
+  formatValue = (v) => `$${v}`,
+}: RangeSliderProps) {
+  const handleMinChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const newMin = Math.min(Number(e.target.value), value.max - step);
+      onChange({ ...value, min: newMin });
+    },
+    [value, onChange, step],
+  );
+
+  const handleMaxChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const newMax = Math.max(Number(e.target.value), value.min + step);
+      onChange({ ...value, max: newMax });
+    },
+    [value, onChange, step],
+  );
+
+  const minPercent = ((value.min - min) / (max - min)) * 100;
+  const maxPercent = ((value.max - min) / (max - min)) * 100;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex justify-between text-sm">
+        <span className="text-slate-400">{minLabel}</span>
+        <span className="text-white font-medium">
+          {formatValue(value.min)} - {formatValue(value.max)}
+        </span>
+      </div>
+      <div className="relative h-2">
+        <div className="absolute inset-0 bg-slate-700 rounded-full" />
+        <div
+          className="absolute h-full bg-gradient-to-r from-cyan-500 to-blue-500 rounded-full"
+          style={{
+            left: `${minPercent}%`,
+            width: `${maxPercent - minPercent}%`,
+          }}
+        />
+        <input
+          type="range"
+          min={min}
+          max={max}
+          step={step}
+          value={value.min}
+          onChange={handleMinChange}
+          className="absolute inset-0 w-full appearance-none bg-transparent cursor-pointer [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-white [&::-webkit-slider-thumb]:shadow-lg [&::-webkit-slider-thumb]:cursor-pointer [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-white [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:shadow-lg [&::-moz-range-thumb]:cursor-pointer"
+        />
+        <input
+          type="range"
+          min={min}
+          max={max}
+          step={step}
+          value={value.max}
+          onChange={handleMaxChange}
+          className="absolute inset-0 w-full appearance-none bg-transparent cursor-pointer [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-white [&::-webkit-slider-thumb]:shadow-lg [&::-webkit-slider-thumb]:cursor-pointer [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-white [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:shadow-lg [&::-moz-range-thumb]:cursor-pointer"
+        />
+      </div>
+    </div>
+  );
+}
+
+interface MultiSelectDropdownProps {
+  label: string;
+  options: { value: string; label: string }[];
+  selectedValues: string[];
+  onToggle: (value: string) => void;
+  counts?: Record<string, number>;
+}
+
+function MultiSelectDropdown({
+  label,
+  options,
+  selectedValues,
+  onToggle,
+  counts,
+}: MultiSelectDropdownProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        className={`flex items-center justify-between w-full h-10 px-3 py-2 text-sm rounded-lg border transition-colors ${
+          isOpen || selectedValues.length > 0
+            ? "bg-slate-800 border-cyan-500 text-white"
+            : "bg-transparent border-slate-700 text-slate-300 hover:border-slate-600"
+        }`}
+      >
+        <span className="truncate">
+          {selectedValues.length > 0
+            ? `${label} (${selectedValues.length})`
+            : label}
+        </span>
+        <ChevronDown
+          className={`ml-2 h-4 w-4 transition-transform ${isOpen ? "rotate-180" : ""}`}
+        />
+      </button>
+
+      {isOpen && (
+        <div className="absolute z-20 mt-1 w-full min-w-[200px] rounded-md bg-slate-800 border border-slate-700 shadow-lg">
+          <ul className="py-1 max-h-60 overflow-auto text-sm">
+            {options.map((option) => (
+              <li key={option.value}>
+                <button
+                  type="button"
+                  onClick={() => {
+                    onToggle(option.value);
+                  }}
+                  className={`w-full px-3 py-2 text-left flex items-center justify-between ${
+                    selectedValues.includes(option.value)
+                      ? "bg-slate-700 text-cyan-400"
+                      : "text-slate-300 hover:bg-slate-700/50"
+                  }`}
+                >
+                  <span className="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      checked={selectedValues.includes(option.value)}
+                      onChange={() => {}}
+                      className="w-4 h-4 rounded border-slate-600 bg-slate-700 text-cyan-500 focus:ring-cyan-500 focus:ring-offset-0"
+                    />
+                    {option.label}
+                  </span>
+                  {counts && counts[option.value] !== undefined && (
+                    <span className="text-xs text-slate-500">
+                      ({counts[option.value]})
+                    </span>
+                  )}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function AdvancedFilterPanel({
+  filterState,
+  activeFilterCount,
+  onSearchChange,
+  onCoverageTypeToggle,
+  onProviderToggle,
+  onPremiumRangeChange,
+  onDeductibleRangeChange,
+  onClearAll,
+}: AdvancedFilterPanelProps) {
+  const [localSearch, setLocalSearch] = useState(filterState.searchQuery);
+  const searchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  // Debounce search input
+  useEffect(() => {
+    if (searchTimeoutRef.current) {
+      clearTimeout(searchTimeoutRef.current);
+    }
+
+    searchTimeoutRef.current = setTimeout(() => {
+      onSearchChange(localSearch);
+    }, 300);
+
+    return () => {
+      if (searchTimeoutRef.current) {
+        clearTimeout(searchTimeoutRef.current);
+      }
+    };
+  }, [localSearch, onSearchChange]);
+
+  // Update local search when URL changes
+  useEffect(() => {
+    setLocalSearch(filterState.searchQuery);
+  }, [filterState.searchQuery]);
+
+  const coverageOptions = ALL_COVERAGE_TYPES.map((type) => ({
+    value: type,
+    label: COVERAGE_TYPE_LABELS[type],
+  }));
+
+  const providerOptions = ALL_PROVIDERS.map((provider) => ({
+    value: provider,
+    label: PROVIDER_LABELS[provider],
+  }));
+
+  const hasActiveFilters = activeFilterCount > 0;
+
+  return (
+    <div className="w-full bg-[#0a1225] dark:bg-[#0a1225] border-b border-slate-800">
+      <div className="max-w-[1440px] mx-auto px-4 sm:px-6 lg:px-8 py-4">
+        {/* Search Bar Row */}
+        <div className="flex items-center gap-3 mb-4">
+          <div className="relative flex-1 max-w-md">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-400" />
+            <input
+              type="text"
+              value={localSearch}
+              onChange={(e) => setLocalSearch(e.target.value)}
+              placeholder="Search policies by name or description..."
+              className="w-full h-10 pl-10 pr-4 rounded-lg bg-slate-800/50 border border-slate-700 text-white placeholder-slate-400 focus:outline-none focus:border-cyan-500 focus:ring-1 focus:ring-cyan-500 transition-colors"
+            />
+            {localSearch && (
+              <button
+                type="button"
+                onClick={() => setLocalSearch("")}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-white"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            )}
+          </div>
+
+          {/* Clear All Button */}
+          {hasActiveFilters && (
+            <button
+              type="button"
+              onClick={onClearAll}
+              className="flex items-center gap-1.5 h-10 px-3 py-2 text-sm font-medium text-rose-400 hover:text-rose-300 rounded-lg border border-rose-500/30 hover:border-rose-500/50 transition-colors"
+            >
+              <X className="h-4 w-4" />
+              Clear All
+              <span className="ml-1 flex items-center justify-center w-5 h-5 text-xs font-bold bg-rose-500/20 rounded-full">
+                {activeFilterCount}
+              </span>
+            </button>
+          )}
+        </div>
+
+        {/* Filter Controls Row */}
+        <div className="flex flex-wrap items-center gap-3">
+          {/* Coverage Type Filter */}
+          <MultiSelectDropdown
+            label="Coverage Type"
+            options={coverageOptions}
+            selectedValues={filterState.coverageTypes}
+            onToggle={(value) => onCoverageTypeToggle(value as CoverageType)}
+          />
+
+          {/* Provider Filter */}
+          <MultiSelectDropdown
+            label="Provider"
+            options={providerOptions}
+            selectedValues={filterState.providers}
+            onToggle={(value) => onProviderToggle(value as ProviderId)}
+          />
+
+          {/* Premium Range */}
+          <div className="w-full sm:w-auto">
+            <RangeSlider
+              min={0}
+              max={1000}
+              value={filterState.premiumRange}
+              onChange={onPremiumRangeChange}
+              minLabel="Premium"
+              step={10}
+              formatValue={(v) => `$${v}/mo`}
+            />
+          </div>
+
+          {/* Deductible Range */}
+          <div className="w-full sm:w-auto">
+            <RangeSlider
+              min={0}
+              max={10000}
+              value={filterState.deductibleRange}
+              onChange={onDeductibleRangeChange}
+              minLabel="Deductible"
+              step={100}
+              formatValue={(v) => `$${v}`}
+            />
+          </div>
+        </div>
+
+        {/* Active Filter Badges */}
+        {hasActiveFilters && (
+          <div className="flex flex-wrap items-center gap-2 mt-4 pt-4 border-t border-slate-800">
+            <span className="text-sm text-slate-400 flex items-center gap-1">
+              <Filter className="h-4 w-4" />
+              Active Filters:
+            </span>
+            {filterState.searchQuery && (
+              <span className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium bg-cyan-500/20 text-cyan-400 rounded-md">
+                Search: "{filterState.searchQuery}"
+                <button
+                  type="button"
+                  onClick={() => onSearchChange("")}
+                  className="hover:text-white"
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </span>
+            )}
+            {filterState.coverageTypes.map((type) => (
+              <span
+                key={type}
+                className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium bg-blue-500/20 text-blue-400 rounded-md"
+              >
+                {COVERAGE_TYPE_LABELS[type]}
+                <button
+                  type="button"
+                  onClick={() => onCoverageTypeToggle(type)}
+                  className="hover:text-white"
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </span>
+            ))}
+            {filterState.providers.map((provider) => (
+              <span
+                key={provider}
+                className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium bg-emerald-500/20 text-emerald-400 rounded-md"
+              >
+                {PROVIDER_LABELS[provider]}
+                <button
+                  type="button"
+                  onClick={() => onProviderToggle(provider)}
+                  className="hover:text-white"
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </span>
+            ))}
+            {(filterState.premiumRange.min > 0 ||
+              filterState.premiumRange.max < 1000) && (
+              <span className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium bg-purple-500/20 text-purple-400 rounded-md">
+                Premium: ${filterState.premiumRange.min} - $
+                {filterState.premiumRange.max}
+                <button
+                  type="button"
+                  onClick={() => onPremiumRangeChange({ min: 0, max: 1000 })}
+                  className="hover:text-white"
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </span>
+            )}
+            {(filterState.deductibleRange.min > 0 ||
+              filterState.deductibleRange.max < 10000) && (
+              <span className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium bg-amber-500/20 text-amber-400 rounded-md">
+                Deductible: ${filterState.deductibleRange.min} - $
+                {filterState.deductibleRange.max}
+                <button
+                  type="button"
+                  onClick={() =>
+                    onDeductibleRangeChange({ min: 0, max: 10000 })
+                  }
+                  className="hover:text-white"
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/policies/listing/PolicyListingGrid.tsx
+++ b/src/components/policies/listing/PolicyListingGrid.tsx
@@ -5,16 +5,78 @@ import { PolicyListingCard } from "./PolicyListingCard";
 type PolicyListingGridProps = {
   items: PolicyCategoryWithLayout[];
   onLearnMore: (item: PolicyCategoryWithLayout) => void;
+  totalCount?: number;
+  filteredCount?: number;
+  isFiltered?: boolean;
 };
 
-export function PolicyListingGrid({ items, onLearnMore }: PolicyListingGridProps) {
+export function PolicyListingGrid({
+  items,
+  onLearnMore,
+  totalCount,
+  filteredCount,
+  isFiltered = false,
+}: PolicyListingGridProps) {
   return (
     <div className="relative z-10 mx-auto w-full max-w-[1200px] px-6 pt-[260px] sm:px-8 sm:pt-[280px] lg:px-0 lg:pt-[300px]">
-      <div className="grid grid-cols-1 place-items-center gap-6 sm:grid-cols-2 sm:gap-8 lg:grid-cols-3 lg:gap-x-10 lg:gap-y-8">
-        {items.map((item) => (
-          <PolicyListingCard key={item.id} item={item} onLearnMore={onLearnMore} />
-        ))}
-      </div>
+      {/* Results count indicator */}
+      {isFiltered &&
+        filteredCount !== undefined &&
+        totalCount !== undefined && (
+          <div className="mb-4 px-2 py-2 bg-slate-800/50 rounded-lg border border-slate-700">
+            <p className="text-sm text-slate-300">
+              Showing{" "}
+              <span className="font-semibold text-cyan-400">
+                {filteredCount}
+              </span>{" "}
+              {filteredCount === totalCount ? "of" : "of"}{" "}
+              <span className="font-semibold text-white">{totalCount}</span>{" "}
+              policies
+              {filteredCount === 0 && (
+                <span className="ml-2 text-amber-400">
+                  (No policies match your filters)
+                </span>
+              )}
+            </p>
+          </div>
+        )}
+
+      {items.length > 0 ? (
+        <div className="grid grid-cols-1 place-items-center gap-6 sm:grid-cols-2 sm:gap-8 lg:grid-cols-3 lg:gap-x-10 lg:gap-y-8">
+          {items.map((item) => (
+            <PolicyListingCard
+              key={item.id}
+              item={item}
+              onLearnMore={onLearnMore}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="flex flex-col items-center justify-center py-16 text-center">
+          <div className="w-16 h-16 mb-4 rounded-full bg-slate-800 flex items-center justify-center">
+            <svg
+              className="w-8 h-8 text-slate-400"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={1.5}
+                d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
+            </svg>
+          </div>
+          <h3 className="text-lg font-semibold text-white mb-2">
+            No policies found
+          </h3>
+          <p className="text-slate-400 max-w-md">
+            Try adjusting your search or filter criteria to find what you're
+            looking for.
+          </p>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/policies/listing/PolicyListingScreen.tsx
+++ b/src/components/policies/listing/PolicyListingScreen.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  Suspense,
+} from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { POLICY_CATEGORIES_MOCK } from "@/data/policies/listing/policy-listing-mock";
 import { PolicyCategoryWithLayout } from "@/types/policies/policy-listing";
@@ -9,17 +15,31 @@ import { PolicyListingGrid } from "./PolicyListingGrid";
 import { PolicyListingLoadingState } from "./PolicyListingLoadingState";
 import { PolicyListingErrorState } from "./PolicyListingErrorState";
 import { PolicyCategoryListingScreen } from "./PolicyCategoryListingScreen";
+import { AdvancedFilterPanel } from "./AdvancedFilterPanel";
+import { usePolicyFilters } from "@/hooks/usePolicyFilters";
 
 type UiStatus = "loading" | "success" | "error";
 
 const SIMULATED_LOADING_MS = 250;
 const SIMULATE_ERROR = false;
 
-export function PolicyListingScreen() {
+function PolicyListingContent() {
   const [status, setStatus] = useState<UiStatus>("loading");
   const router = useRouter();
   const searchParams = useSearchParams();
   const categoryId = searchParams.get("category");
+
+  // Use the filter hook
+  const {
+    filterState,
+    activeFilterCount,
+    setSearchQuery,
+    toggleCoverageType,
+    toggleProvider,
+    setPremiumRange,
+    setDeductibleRange,
+    clearAllFilters,
+  } = usePolicyFilters();
 
   const items = useMemo<PolicyCategoryWithLayout[]>(() => {
     return POLICY_CATEGORIES_MOCK.map((c) => ({
@@ -27,6 +47,36 @@ export function PolicyListingScreen() {
       layout: POLICY_CATEGORY_LAYOUT[c.id],
     }));
   }, []);
+
+  // Filter items based on active filters
+  const filteredItems = useMemo(() => {
+    if (activeFilterCount === 0) {
+      return items;
+    }
+
+    return items.filter((item) => {
+      // Filter by search query
+      if (filterState.searchQuery) {
+        const query = filterState.searchQuery.toLowerCase();
+        const matchesTitle = item.title.toLowerCase().includes(query);
+        const matchesDescription = item.description
+          .toLowerCase()
+          .includes(query);
+        if (!matchesTitle && !matchesDescription) {
+          return false;
+        }
+      }
+
+      // Filter by coverage types
+      if (filterState.coverageTypes.length > 0) {
+        if (!filterState.coverageTypes.includes(item.id as any)) {
+          return false;
+        }
+      }
+
+      return true;
+    });
+  }, [items, filterState, activeFilterCount]);
 
   const load = useCallback(() => {
     setStatus("loading");
@@ -37,44 +87,93 @@ export function PolicyListingScreen() {
   }, []);
 
   useEffect(() => {
-    if (!categoryId) {
-      load();
-    }
-  }, [load, categoryId]);
+    load();
+  }, [load]);
 
   const handleLearnMore = useCallback(
     (item: PolicyCategoryWithLayout) => {
       router.push(`/policies/listing?category=${item.id}`);
     },
-    [router]
+    [router],
   );
 
   return (
-    <div className="relative w-full max-w-[1440px] min-h-screen bg-[#101935] overflow-hidden">
+    <div className="relative w-full max-w-[1440px] min-h-screen bg-white dark:bg-[#101935] overflow-hidden">
       {categoryId ? (
         <PolicyCategoryListingScreen categoryId={categoryId} />
       ) : (
         <>
+          {/* Advanced Filter Panel */}
+          <AdvancedFilterPanel
+            filterState={filterState}
+            activeFilterCount={activeFilterCount}
+            onSearchChange={setSearchQuery}
+            onCoverageTypeToggle={toggleCoverageType}
+            onProviderToggle={toggleProvider}
+            onPremiumRangeChange={setPremiumRange}
+            onDeductibleRangeChange={setDeductibleRange}
+            onClearAll={clearAllFilters}
+          />
+
+          <div className="absolute left-1/2 top-14 w-full max-w-[1040px] -translate-x-1/2 px-6 text-center pointer-events-none sm:top-20 lg:top-[90px]">
+            <h1 className="text-black dark:text-white text-[28px] font-bold leading-tight sm:text-[36px] lg:text-[40px]">
+              Insurance Categories
+            </h1>
+            <p className="mt-3 mx-auto max-w-[960px] text-gray-700 dark:text-white text-[14px] font-semibold leading-relaxed sm:text-[16px] lg:text-[18px]">
+              We offer a wide range of insurance products to protect what
+              matters most to you, all
+              <br className="hidden sm:block" />
+              powered by blockchain technology.
+            </p>
+          </div>
+
+          {status === "loading" && <PolicyListingLoadingState />}
+
+          {status === "error" && (
+            <PolicyListingErrorState
+              message="Unable to load policy categories."
+              onRetry={load}
+            />
+          )}
+
+          {status === "success" && (
+            <PolicyListingGrid
+              items={filteredItems}
+              onLearnMore={handleLearnMore}
+              totalCount={items.length}
+              filteredCount={filteredItems.length}
+              isFiltered={activeFilterCount > 0}
+            />
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function PolicyListingLoading() {
+  return (
+    <div className="relative w-full max-w-[1440px] min-h-screen bg-white dark:bg-[#101935] overflow-hidden">
       <div className="absolute left-1/2 top-14 w-full max-w-[1040px] -translate-x-1/2 px-6 text-center pointer-events-none sm:top-20 lg:top-[90px]">
-        <h1 className="text-[#080D24] text-[28px] font-bold leading-tight sm:text-[36px] lg:text-[40px]">
+        <h1 className="text-black dark:text-white text-[28px] font-bold leading-tight sm:text-[36px] lg:text-[40px]">
           Insurance Categories
         </h1>
-        <p className="mt-3 mx-auto max-w-[960px] text-white text-[14px] font-semibold leading-relaxed sm:text-[16px] lg:text-[18px]">
-          We offer a wide range of insurance products to protect what matters most to you, all
+        <p className="mt-3 mx-auto max-w-[960px] text-gray-700 dark:text-white text-[14px] font-semibold leading-relaxed sm:text-[16px] lg:text-[18px]">
+          We offer a wide range of insurance products to protect what matters
+          most to you, all
           <br className="hidden sm:block" />
           powered by blockchain technology.
         </p>
       </div>
-
-      {status === "loading" && <PolicyListingLoadingState />}
-
-      {status === "error" && (
-        <PolicyListingErrorState message="Unable to load policy categories." onRetry={load} />
-      )}
-
-      {status === "success" && <PolicyListingGrid items={items} onLearnMore={handleLearnMore} />}
-        </>
-      )}
+      <PolicyListingLoadingState />
     </div>
+  );
+}
+
+export function PolicyListingScreen() {
+  return (
+    <Suspense fallback={<PolicyListingLoading />}>
+      <PolicyListingContent />
+    </Suspense>
   );
 }

--- a/src/hooks/usePolicyFilters.ts
+++ b/src/hooks/usePolicyFilters.ts
@@ -1,0 +1,205 @@
+"use client";
+
+import { useCallback, useMemo, useEffect, useState } from "react";
+import { useSearchParams, useRouter, usePathname } from "next/navigation";
+import {
+  PolicyFilterState,
+  DEFAULT_FILTER_STATE,
+  CoverageType,
+  ProviderId,
+} from "@/types/policies/filter";
+
+const DEBOUNCE_DELAY = 300;
+
+export function usePolicyFilters() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+
+  // Parse URL params into filter state
+  const filterState = useMemo<PolicyFilterState>(() => {
+    const searchQuery = searchParams.get("q") || "";
+    const coverageTypes =
+      (searchParams
+        .get("coverage")
+        ?.split(",")
+        .filter(Boolean) as CoverageType[]) || [];
+    const providers =
+      (searchParams
+        .get("providers")
+        ?.split(",")
+        .filter(Boolean) as ProviderId[]) || [];
+    const premiumMin = Number(searchParams.get("premiumMin")) || 0;
+    const premiumMax = Number(searchParams.get("premiumMax")) || 1000;
+    const deductibleMin = Number(searchParams.get("deductibleMin")) || 0;
+    const deductibleMax = Number(searchParams.get("deductibleMax")) || 10000;
+
+    return {
+      searchQuery,
+      coverageTypes,
+      providers,
+      premiumRange: { min: premiumMin, max: premiumMax },
+      deductibleRange: { min: deductibleMin, max: deductibleMax },
+    };
+  }, [searchParams]);
+
+  // Update URL with new filter state
+  const updateURL = useCallback(
+    (newState: Partial<PolicyFilterState>) => {
+      const params = new URLSearchParams(searchParams.toString());
+
+      // Handle search query
+      if (newState.searchQuery !== undefined) {
+        if (newState.searchQuery) {
+          params.set("q", newState.searchQuery);
+        } else {
+          params.delete("q");
+        }
+      }
+
+      // Handle coverage types
+      if (newState.coverageTypes !== undefined) {
+        if (newState.coverageTypes.length > 0) {
+          params.set("coverage", newState.coverageTypes.join(","));
+        } else {
+          params.delete("coverage");
+        }
+      }
+
+      // Handle providers
+      if (newState.providers !== undefined) {
+        if (newState.providers.length > 0) {
+          params.set("providers", newState.providers.join(","));
+        } else {
+          params.delete("providers");
+        }
+      }
+
+      // Handle premium range
+      if (newState.premiumRange !== undefined) {
+        if (newState.premiumRange.min > 0) {
+          params.set("premiumMin", String(newState.premiumRange.min));
+        } else {
+          params.delete("premiumMin");
+        }
+        if (newState.premiumRange.max < 1000) {
+          params.set("premiumMax", String(newState.premiumRange.max));
+        } else {
+          params.delete("premiumMax");
+        }
+      }
+
+      // Handle deductible range
+      if (newState.deductibleRange !== undefined) {
+        if (newState.deductibleRange.min > 0) {
+          params.set("deductibleMin", String(newState.deductibleRange.min));
+        } else {
+          params.delete("deductibleMin");
+        }
+        if (newState.deductibleRange.max < 10000) {
+          params.set("deductibleMax", String(newState.deductibleRange.max));
+        } else {
+          params.delete("deductibleMax");
+        }
+      }
+
+      const newURL = params.toString()
+        ? `${pathname}?${params.toString()}`
+        : pathname;
+
+      router.replace(newURL, { scroll: false });
+    },
+    [pathname, router, searchParams],
+  );
+
+  // Debounced search handler
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSearch(filterState.searchQuery);
+    }, DEBOUNCE_DELAY);
+
+    return () => clearTimeout(timer);
+  }, [filterState.searchQuery]);
+
+  // Set search query with debounce
+  const setSearchQuery = useCallback(
+    (query: string) => {
+      updateURL({ searchQuery: query });
+    },
+    [updateURL],
+  );
+
+  // Toggle coverage type
+  const toggleCoverageType = useCallback(
+    (type: CoverageType) => {
+      const current = filterState.coverageTypes;
+      const newTypes = current.includes(type)
+        ? current.filter((t) => t !== type)
+        : [...current, type];
+      updateURL({ coverageTypes: newTypes });
+    },
+    [filterState.coverageTypes, updateURL],
+  );
+
+  // Toggle provider
+  const toggleProvider = useCallback(
+    (provider: ProviderId) => {
+      const current = filterState.providers;
+      const newProviders = current.includes(provider)
+        ? current.filter((p) => p !== provider)
+        : [...current, provider];
+      updateURL({ providers: newProviders });
+    },
+    [filterState.providers, updateURL],
+  );
+
+  // Set premium range
+  const setPremiumRange = useCallback(
+    (range: { min: number; max: number }) => {
+      updateURL({ premiumRange: range });
+    },
+    [updateURL],
+  );
+
+  // Set deductible range
+  const setDeductibleRange = useCallback(
+    (range: { min: number; max: number }) => {
+      updateURL({ deductibleRange: range });
+    },
+    [updateURL],
+  );
+
+  // Clear all filters
+  const clearAllFilters = useCallback(() => {
+    router.replace(pathname, { scroll: false });
+  }, [pathname, router]);
+
+  // Count active filters
+  const activeFilterCount = useMemo(() => {
+    let count = 0;
+    if (filterState.searchQuery) count++;
+    if (filterState.coverageTypes.length > 0) count++;
+    if (filterState.providers.length > 0) count++;
+    if (filterState.premiumRange.min > 0 || filterState.premiumRange.max < 1000)
+      count++;
+    if (
+      filterState.deductibleRange.min > 0 ||
+      filterState.deductibleRange.max < 10000
+    )
+      count++;
+    return count;
+  }, [filterState]);
+
+  return {
+    filterState,
+    debouncedSearch,
+    activeFilterCount,
+    setSearchQuery,
+    toggleCoverageType,
+    toggleProvider,
+    setPremiumRange,
+    setDeductibleRange,
+    clearAllFilters,
+  };
+}

--- a/src/types/policies/filter.ts
+++ b/src/types/policies/filter.ts
@@ -1,0 +1,87 @@
+export type CoverageType =
+  | "health"
+  | "vehicle"
+  | "property"
+  | "travel"
+  | "crypto"
+  | "life"
+  | "dental"
+  | "vision";
+
+export type ProviderId =
+  | "stellar-protect"
+  | "blockchain-insure"
+  | "crypto-shield"
+  | "defi-guard"
+  | "dao-cover";
+
+export interface PolicyFilterState {
+  searchQuery: string;
+  coverageTypes: CoverageType[];
+  providers: ProviderId[];
+  premiumRange: {
+    min: number;
+    max: number;
+  };
+  deductibleRange: {
+    min: number;
+    max: number;
+  };
+}
+
+export interface FilterCount {
+  coverageType: Record<CoverageType, number>;
+  provider: Record<ProviderId, number>;
+}
+
+export const DEFAULT_FILTER_STATE: PolicyFilterState = {
+  searchQuery: "",
+  coverageTypes: [],
+  providers: [],
+  premiumRange: {
+    min: 0,
+    max: 1000,
+  },
+  deductibleRange: {
+    min: 0,
+    max: 10000,
+  },
+};
+
+export const COVERAGE_TYPE_LABELS: Record<CoverageType, string> = {
+  health: "Health",
+  vehicle: "Vehicle",
+  property: "Property",
+  travel: "Travel",
+  crypto: "Crypto",
+  life: "Life",
+  dental: "Dental",
+  vision: "Vision",
+};
+
+export const PROVIDER_LABELS: Record<ProviderId, string> = {
+  "stellar-protect": "Stellar Protect",
+  "blockchain-insure": "Blockchain Insure",
+  "crypto-shield": "Crypto Shield",
+  "defi-guard": "DeFi Guard",
+  "dao-cover": "DAO Cover",
+};
+
+export const ALL_COVERAGE_TYPES: CoverageType[] = [
+  "health",
+  "vehicle",
+  "property",
+  "travel",
+  "crypto",
+  "life",
+  "dental",
+  "vision",
+];
+
+export const ALL_PROVIDERS: ProviderId[] = [
+  "stellar-protect",
+  "blockchain-insure",
+  "crypto-shield",
+  "defi-guard",
+  "dao-cover",
+];


### PR DESCRIPTION
Closes #51

---

## Summary
Implemented advanced search and filtering system for the policy listing page.

## Changes
- Add AdvancedFilterPanel component with full-text search, multi-select filters for coverage types and providers, and range sliders
- Create usePolicyFilters hook for URL-based filter state management
- Update PolicyListingGrid to show results count
- Add filter badges and "Clear all filters" functionality

## Features
- Full-text search across policy names and descriptions
- Multi-select filtering by coverage type
- Provider-based filtering
- Premium range slider ($0-$1000/mo)
- Deductible range slider ($0-$10,000)
- Filter persistence via URL params for sharing
- Real-time filtering without page reload
- Results count indicator

## Test URLs
- /policies/listing?q=health
- /policies/listing?coverage=health,crypto&providers=stellar-protect
