### PR TITLE
feat: Add Centralized API Abstraction Layer for Backend Communication

### DIFF
--- a/src/lib/__tests__/api-client.test.ts
+++ b/src/lib/__tests__/api-client.test.ts
@@ -1,0 +1,372 @@
+/**
+ * Tests for the centralized API client.
+ */
+
+import { ApiClientError } from '@/lib/api-client';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function mockFetch(
+  status: number,
+  body: unknown = {},
+  headers: Record<string, string> = {}
+) {
+  return jest.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: `Status ${status}`,
+    headers: new Headers(headers),
+    json: jest.fn().mockResolvedValue(body),
+  });
+}
+
+// We re-import the module in each test so interceptors don't leak across tests.
+function loadClient() {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const mod = require('@/lib/api-client');
+  return mod.apiClient as typeof import('@/lib/api-client').apiClient;
+}
+
+// ─── Setup ───────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  jest.resetModules();
+  jest.restoreAllMocks();
+  // Provide a mock localStorage
+  const store: Record<string, string> = {};
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: {
+      getItem: jest.fn((key: string) => store[key] ?? null),
+      setItem: jest.fn((key: string, val: string) => {
+        store[key] = val;
+      }),
+      removeItem: jest.fn((key: string) => {
+        delete store[key];
+      }),
+    },
+    writable: true,
+    configurable: true,
+  });
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('ApiClient', () => {
+  describe('HTTP methods', () => {
+    it('GET request sends correct method and returns data', async () => {
+      const fetchMock = mockFetch(200, { id: 1, name: 'test' });
+      globalThis.fetch = fetchMock;
+      const client = loadClient();
+
+      const result = await client.get<{ id: number; name: string }>('/items');
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toContain('/items');
+      expect(init.method).toBe('GET');
+      expect(result.data).toEqual({ id: 1, name: 'test' });
+      expect(result.status).toBe(200);
+    });
+
+    it('POST request sends body as JSON', async () => {
+      const fetchMock = mockFetch(201, { id: 99 });
+      globalThis.fetch = fetchMock;
+      const client = loadClient();
+
+      await client.post('/items', { name: 'new' });
+
+      const [, init] = fetchMock.mock.calls[0];
+      expect(init.method).toBe('POST');
+      expect(init.body).toBe(JSON.stringify({ name: 'new' }));
+    });
+
+    it('PUT request sends body as JSON', async () => {
+      const fetchMock = mockFetch(200, { updated: true });
+      globalThis.fetch = fetchMock;
+      const client = loadClient();
+
+      await client.put('/items/1', { name: 'updated' });
+
+      const [, init] = fetchMock.mock.calls[0];
+      expect(init.method).toBe('PUT');
+      expect(init.body).toBe(JSON.stringify({ name: 'updated' }));
+    });
+
+    it('PATCH request sends body as JSON', async () => {
+      const fetchMock = mockFetch(200, { patched: true });
+      globalThis.fetch = fetchMock;
+      const client = loadClient();
+
+      await client.patch('/items/1', { status: 'done' });
+
+      const [, init] = fetchMock.mock.calls[0];
+      expect(init.method).toBe('PATCH');
+    });
+
+    it('DELETE request sends correct method', async () => {
+      const fetchMock = mockFetch(204);
+      globalThis.fetch = fetchMock;
+      const client = loadClient();
+
+      const result = await client.delete('/items/1');
+
+      const [, init] = fetchMock.mock.calls[0];
+      expect(init.method).toBe('DELETE');
+      expect(result.status).toBe(204);
+    });
+  });
+
+  describe('Query params', () => {
+    it('appends query parameters to URL', async () => {
+      const fetchMock = mockFetch(200, []);
+      globalThis.fetch = fetchMock;
+      const client = loadClient();
+
+      await client.get('/items', { params: { page: 2, status: 'active' } });
+
+      const url: string = fetchMock.mock.calls[0][0];
+      expect(url).toContain('page=2');
+      expect(url).toContain('status=active');
+    });
+
+    it('omits undefined params', async () => {
+      const fetchMock = mockFetch(200, []);
+      globalThis.fetch = fetchMock;
+      const client = loadClient();
+
+      await client.get('/items', { params: { page: 1, status: undefined } });
+
+      const url: string = fetchMock.mock.calls[0][0];
+      expect(url).toContain('page=1');
+      expect(url).not.toContain('status');
+    });
+  });
+
+  describe('Error handling', () => {
+    it('throws ApiClientError on non-ok response', async () => {
+      const fetchMock = mockFetch(404, { message: 'Not found', code: 'NOT_FOUND' });
+      globalThis.fetch = fetchMock;
+      const client = loadClient();
+
+      await expect(client.get('/missing')).rejects.toThrow('Not found');
+      try {
+        await client.get('/missing');
+      } catch (err: unknown) {
+        const e = err as { status: number; code: string; name: string };
+        expect(e.name).toBe('ApiClientError');
+        expect(e.status).toBe(404);
+        expect(e.code).toBe('NOT_FOUND');
+      }
+    });
+
+    it('throws ApiClientError with NETWORK_ERROR on fetch failure', async () => {
+      globalThis.fetch = jest.fn().mockRejectedValue(new TypeError('Failed to fetch'));
+      const client = loadClient();
+
+      await expect(client.get('/offline')).rejects.toThrow('Failed to fetch');
+      try {
+        await client.get('/offline');
+      } catch (err: unknown) {
+        const e = err as { code: string; name: string };
+        expect(e.name).toBe('ApiClientError');
+        expect(e.code).toBe('NETWORK_ERROR');
+      }
+    });
+
+    it('throws on abort / timeout with ABORT code', async () => {
+      globalThis.fetch = jest.fn().mockRejectedValue(
+        new DOMException('Aborted', 'AbortError')
+      );
+      const client = loadClient();
+
+      await expect(client.get('/slow')).rejects.toThrow();
+      try {
+        await client.get('/slow');
+      } catch (err: unknown) {
+        const e = err as { code: string; name: string };
+        expect(e.name).toBe('ApiClientError');
+        expect(e.code).toBe('ABORT');
+      }
+    });
+  });
+
+  describe('Request interceptors', () => {
+    it('modifies request through interceptor', async () => {
+      const fetchMock = mockFetch(200, {});
+      globalThis.fetch = fetchMock;
+      const client = loadClient();
+
+      client.onRequest(async (url, config) => {
+        const headers = new Headers(config.headers);
+        headers.set('X-Custom', 'test-value');
+        return [url, { ...config, headers }];
+      });
+
+      await client.get('/test');
+
+      const [, init] = fetchMock.mock.calls[0];
+      const headers = new Headers(init.headers);
+      expect(headers.get('X-Custom')).toBe('test-value');
+    });
+
+    it('auth interceptor adds token from wallet store', async () => {
+      const fetchMock = mockFetch(200, {});
+      globalThis.fetch = fetchMock;
+
+      (localStorage.getItem as jest.Mock).mockReturnValue(
+        JSON.stringify({ state: { session: { token: 'my-jwt-token' } } })
+      );
+
+      const client = loadClient();
+      await client.get('/protected');
+
+      const [, init] = fetchMock.mock.calls[0];
+      const headers = new Headers(init.headers);
+      expect(headers.get('Authorization')).toBe('Bearer my-jwt-token');
+    });
+
+    it('proceeds without auth when no token stored', async () => {
+      const fetchMock = mockFetch(200, {});
+      globalThis.fetch = fetchMock;
+      (localStorage.getItem as jest.Mock).mockReturnValue(null);
+
+      const client = loadClient();
+      await client.get('/public');
+
+      const [, init] = fetchMock.mock.calls[0];
+      const headers = new Headers(init.headers);
+      expect(headers.get('Authorization')).toBeNull();
+    });
+  });
+
+  describe('Response interceptors', () => {
+    it('transforms the response through interceptor', async () => {
+      const fetchMock = mockFetch(200, { original: true });
+      globalThis.fetch = fetchMock;
+      const client = loadClient();
+
+      client.onResponse(async (response) => {
+        // return response as-is (interceptor ran)
+        return response;
+      });
+
+      const result = await client.get('/transformed');
+      expect(result.data).toEqual({ original: true });
+    });
+  });
+
+  describe('Error interceptors', () => {
+    it('runs error interceptor on API error', async () => {
+      const fetchMock = mockFetch(500, { message: 'Internal Server Error' });
+      globalThis.fetch = fetchMock;
+      const client = loadClient();
+
+      const intercepted: ApiClientError[] = [];
+      client.onError((error) => {
+        intercepted.push(error);
+        return error;
+      });
+
+      await expect(client.get('/fail')).rejects.toThrow();
+      expect(intercepted).toHaveLength(1);
+      expect(intercepted[0].status).toBe(500);
+    });
+  });
+
+  describe('Interceptor removal', () => {
+    it('unregisters interceptor when dispose is called', async () => {
+      const fetchMock = mockFetch(200, {});
+      globalThis.fetch = fetchMock;
+      const client = loadClient();
+
+      let callCount = 0;
+      const remove = client.onRequest(async (url, config) => {
+        callCount++;
+        return [url, config];
+      });
+
+      await client.get('/first');
+      expect(callCount).toBe(1);
+
+      remove();
+
+      await client.get('/second');
+      // Only the default auth interceptor should run, not our custom one
+      expect(callCount).toBe(1);
+    });
+  });
+
+  describe('Request cancellation', () => {
+    it('cancelRequest aborts the controller', () => {
+      const client = loadClient();
+      const controller = client.createCancelToken('test-req');
+
+      expect(controller.signal.aborted).toBe(false);
+      client.cancelRequest('test-req');
+      expect(controller.signal.aborted).toBe(true);
+    });
+
+    it('createCancelToken replaces previous controller with same key', () => {
+      const client = loadClient();
+      const first = client.createCancelToken('same-key');
+      const second = client.createCancelToken('same-key');
+
+      expect(first.signal.aborted).toBe(true);
+      expect(second.signal.aborted).toBe(false);
+    });
+
+    it('cancelAll aborts all active controllers', () => {
+      const client = loadClient();
+      const a = client.createCancelToken('a');
+      const b = client.createCancelToken('b');
+
+      client.cancelAll();
+      expect(a.signal.aborted).toBe(true);
+      expect(b.signal.aborted).toBe(true);
+    });
+  });
+
+  describe('Retry logic', () => {
+    it('retries on failure when retries > 0', async () => {
+      let callCount = 0;
+      globalThis.fetch = jest.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount < 3) {
+          return Promise.reject(new TypeError('Network error'));
+        }
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          headers: new Headers(),
+          json: () => Promise.resolve({ success: true }),
+        });
+      });
+
+      const client = loadClient();
+      const result = await client.get<{ success: boolean }>('/retry-me', {
+        retries: 3,
+      });
+
+      expect(result.data).toEqual({ success: true });
+      expect(callCount).toBe(3);
+    }, 30000);
+  });
+
+  describe('204 No Content', () => {
+    it('handles 204 responses without trying to parse JSON', async () => {
+      globalThis.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 204,
+        statusText: 'No Content',
+        headers: new Headers(),
+        json: jest.fn().mockRejectedValue(new Error('No body')),
+      });
+      const client = loadClient();
+
+      const result = await client.delete('/items/1');
+      expect(result.status).toBe(204);
+      expect(result.data).toBeUndefined();
+    });
+  });
+});

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -1,0 +1,390 @@
+/**
+ * Centralized API client for backend communication.
+ * Provides request/response interceptors, auth token management,
+ * retry logic with exponential backoff, and request cancellation.
+ */
+
+import { errorHandler, type ErrorCategory } from '@/lib/errorHandler';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface ApiResponse<T = unknown> {
+  data: T;
+  status: number;
+  headers: Headers;
+}
+
+export interface ApiError {
+  message: string;
+  status: number;
+  code?: string;
+  details?: unknown;
+}
+
+export interface RequestConfig extends Omit<RequestInit, 'body'> {
+  params?: Record<string, string | number | boolean | undefined>;
+  timeout?: number;
+  retries?: number;
+  body?: unknown;
+}
+
+type RequestInterceptor = (
+  url: string,
+  config: RequestInit
+) => [string, RequestInit] | Promise<[string, RequestInit]>;
+
+type ResponseInterceptor = (response: Response) => Response | Promise<Response>;
+
+type ErrorInterceptor = (error: ApiClientError) => ApiClientError;
+
+export interface ApiClientConfig {
+  baseURL: string;
+  defaultHeaders?: Record<string, string>;
+  timeout?: number;
+  retries?: number;
+}
+
+// ─── Custom Error ────────────────────────────────────────────────────────────
+
+export class ApiClientError extends Error {
+  status: number;
+  code: string;
+  details: unknown;
+
+  constructor(message: string, status: number, code?: string, details?: unknown) {
+    super(message);
+    this.name = 'ApiClientError';
+    this.status = status;
+    this.code = code ?? 'UNKNOWN_ERROR';
+    this.details = details;
+  }
+}
+
+// ─── API Client Class ────────────────────────────────────────────────────────
+
+class ApiClient {
+  private baseURL: string;
+  private defaultHeaders: Record<string, string>;
+  private defaultTimeout: number;
+  private defaultRetries: number;
+
+  private requestInterceptors: RequestInterceptor[] = [];
+  private responseInterceptors: ResponseInterceptor[] = [];
+  private errorInterceptors: ErrorInterceptor[] = [];
+
+  // Track active AbortControllers for cancellation
+  private activeControllers = new Map<string, AbortController>();
+
+  constructor(config: ApiClientConfig) {
+    this.baseURL = config.baseURL.replace(/\/+$/, '');
+    this.defaultHeaders = {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      ...config.defaultHeaders,
+    };
+    this.defaultTimeout = config.timeout ?? 30_000;
+    this.defaultRetries = config.retries ?? 0;
+  }
+
+  // ─── Interceptor Registration ────────────────────────────────────────────
+
+  onRequest(interceptor: RequestInterceptor): () => void {
+    this.requestInterceptors.push(interceptor);
+    return () => {
+      this.requestInterceptors = this.requestInterceptors.filter(
+        (i) => i !== interceptor
+      );
+    };
+  }
+
+  onResponse(interceptor: ResponseInterceptor): () => void {
+    this.responseInterceptors.push(interceptor);
+    return () => {
+      this.responseInterceptors = this.responseInterceptors.filter(
+        (i) => i !== interceptor
+      );
+    };
+  }
+
+  onError(interceptor: ErrorInterceptor): () => void {
+    this.errorInterceptors.push(interceptor);
+    return () => {
+      this.errorInterceptors = this.errorInterceptors.filter(
+        (i) => i !== interceptor
+      );
+    };
+  }
+
+  // ─── Request Cancellation ────────────────────────────────────────────────
+
+  /**
+   * Create a cancellable request. Returns an AbortController
+   * that the caller can use to cancel the in-flight request.
+   */
+  createCancelToken(key: string): AbortController {
+    // Cancel any previous request with the same key
+    this.cancelRequest(key);
+
+    const controller = new AbortController();
+    this.activeControllers.set(key, controller);
+    return controller;
+  }
+
+  cancelRequest(key: string): void {
+    const controller = this.activeControllers.get(key);
+    if (controller) {
+      controller.abort();
+      this.activeControllers.delete(key);
+    }
+  }
+
+  cancelAll(): void {
+    this.activeControllers.forEach((controller) => controller.abort());
+    this.activeControllers.clear();
+  }
+
+  // ─── HTTP Methods ────────────────────────────────────────────────────────
+
+  async get<T>(path: string, config?: RequestConfig): Promise<ApiResponse<T>> {
+    return this.request<T>(path, { ...config, method: 'GET' });
+  }
+
+  async post<T>(
+    path: string,
+    data?: unknown,
+    config?: RequestConfig
+  ): Promise<ApiResponse<T>> {
+    return this.request<T>(path, { ...config, method: 'POST', body: data });
+  }
+
+  async put<T>(
+    path: string,
+    data?: unknown,
+    config?: RequestConfig
+  ): Promise<ApiResponse<T>> {
+    return this.request<T>(path, { ...config, method: 'PUT', body: data });
+  }
+
+  async patch<T>(
+    path: string,
+    data?: unknown,
+    config?: RequestConfig
+  ): Promise<ApiResponse<T>> {
+    return this.request<T>(path, { ...config, method: 'PATCH', body: data });
+  }
+
+  async delete<T>(path: string, config?: RequestConfig): Promise<ApiResponse<T>> {
+    return this.request<T>(path, { ...config, method: 'DELETE' });
+  }
+
+  // ─── Core Request Logic ──────────────────────────────────────────────────
+
+  private async request<T>(
+    path: string,
+    config: RequestConfig & { method: string }
+  ): Promise<ApiResponse<T>> {
+    const url = this.buildURL(path, config.params);
+    const retries = config.retries ?? this.defaultRetries;
+    const timeout = config.timeout ?? this.defaultTimeout;
+
+    const { params: _params, timeout: _timeout, retries: _retries, body, ...fetchOptions } = config;
+
+    // Build RequestInit
+    let init: RequestInit = {
+      ...fetchOptions,
+      headers: {
+        ...this.defaultHeaders,
+        ...(config.headers as Record<string, string>),
+      },
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    };
+
+    // Run request interceptors
+    let finalUrl = url;
+    for (const interceptor of this.requestInterceptors) {
+      [finalUrl, init] = await interceptor(finalUrl, init);
+    }
+
+    // Execute with retry logic
+    const execute = async (): Promise<ApiResponse<T>> => {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+      // Merge signals: if caller provided one via cancelToken, combine them
+      const existingSignal = init.signal;
+      if (existingSignal) {
+        existingSignal.addEventListener('abort', () => controller.abort());
+      }
+
+      try {
+        let response = await fetch(finalUrl, {
+          ...init,
+          signal: controller.signal,
+        });
+
+        clearTimeout(timeoutId);
+
+        // Run response interceptors
+        for (const interceptor of this.responseInterceptors) {
+          response = await interceptor(response);
+        }
+
+        if (!response.ok) {
+          const errorBody = await this.safeParseJSON(response);
+          throw new ApiClientError(
+            (errorBody?.message as string) ?? response.statusText,
+            response.status,
+            errorBody?.code as string | undefined,
+            errorBody
+          );
+        }
+
+        // Handle 204 No Content
+        if (response.status === 204) {
+          return {
+            data: undefined as T,
+            status: response.status,
+            headers: response.headers,
+          };
+        }
+
+        const data = await response.json() as T;
+        return { data, status: response.status, headers: response.headers };
+      } catch (error) {
+        clearTimeout(timeoutId);
+
+        if (error instanceof ApiClientError) {
+          let processed = error;
+          for (const interceptor of this.errorInterceptors) {
+            processed = interceptor(processed);
+          }
+          throw processed;
+        }
+
+        // Network errors or aborts
+        if (error instanceof DOMException && error.name === 'AbortError') {
+          throw new ApiClientError('Request was cancelled or timed out', 0, 'ABORT');
+        }
+
+        throw new ApiClientError(
+          error instanceof Error ? error.message : 'Network error',
+          0,
+          'NETWORK_ERROR'
+        );
+      }
+    };
+
+    // Retry with exponential backoff via errorHandler
+    if (retries > 0) {
+      return errorHandler.retryWithBackoff<ApiResponse<T>>(
+        execute,
+        'NETWORK' as ErrorCategory,
+        {
+          maxRetries: retries,
+          baseDelay: 1000,
+          maxDelay: 8000,
+          exponentialFactor: 2,
+          jitter: true,
+        }
+      );
+    }
+
+    return execute();
+  }
+
+  // ─── Helpers ─────────────────────────────────────────────────────────────
+
+  private buildURL(
+    path: string,
+    params?: Record<string, string | number | boolean | undefined>
+  ): string {
+    const url = new URL(`${this.baseURL}${path.startsWith('/') ? '' : '/'}${path}`);
+    if (params) {
+      Object.entries(params).forEach(([key, value]) => {
+        if (value !== undefined) {
+          url.searchParams.set(key, String(value));
+        }
+      });
+    }
+    return url.toString();
+  }
+
+  private async safeParseJSON(response: Response): Promise<Record<string, unknown> | null> {
+    try {
+      return await response.json();
+    } catch {
+      return null;
+    }
+  }
+}
+
+// ─── Default Instance ────────────────────────────────────────────────────────
+
+const BASE_URL =
+  typeof process !== 'undefined'
+    ? process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:4000'
+    : 'http://localhost:4000';
+
+export const apiClient = new ApiClient({
+  baseURL: BASE_URL,
+  timeout: 30_000,
+  retries: 0,
+});
+
+// ─── Auth Token Interceptor ──────────────────────────────────────────────────
+
+apiClient.onRequest(async (url, config) => {
+  // Read the auth token from the wallet store persisted in localStorage
+  if (typeof window !== 'undefined') {
+    try {
+      const raw = localStorage.getItem('wallet-store');
+      if (raw) {
+        const store = JSON.parse(raw);
+        const token = store?.state?.session?.token;
+        if (token) {
+          const headers = new Headers(config.headers);
+          headers.set('Authorization', `Bearer ${token}`);
+          return [url, { ...config, headers }];
+        }
+      }
+    } catch {
+      // Ignore parse errors — proceed without auth header
+    }
+  }
+  return [url, config];
+});
+
+// ─── Error Categorization Interceptor ────────────────────────────────────────
+
+apiClient.onError((error) => {
+  const category: ErrorCategory =
+    error.status === 401 || error.status === 403
+      ? 'AUTHENTICATION'
+      : error.status >= 400 && error.status < 500
+        ? 'VALIDATION'
+        : error.status >= 500
+          ? 'NETWORK'
+          : 'NETWORK';
+
+  const codeMap: Record<number, string> = {
+    401: 'UNAUTHORIZED',
+    403: 'UNAUTHORIZED',
+    404: 'NOT_FOUND',
+    422: 'INVALID_INPUT',
+    429: 'RATE_LIMITED',
+    500: 'SERVER_ERROR',
+    502: 'SERVER_ERROR',
+    503: 'SERVER_ERROR',
+  };
+
+  errorHandler.handleError(
+    category,
+    codeMap[error.status] ?? 'GENERIC_ERROR',
+    error,
+    { url: error.message, status: error.status }
+  );
+
+  return error;
+});
+
+export default apiClient;

--- a/src/lib/types/api.types.ts
+++ b/src/lib/types/api.types.ts
@@ -1,0 +1,30 @@
+/**
+ * Shared API response types used across all service modules.
+ */
+
+/** Standard paginated list envelope returned by the backend. */
+export interface PaginatedResponse<T> {
+  items: T[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+}
+
+/** Standard single-resource envelope. */
+export interface SingleResponse<T> {
+  data: T;
+  message?: string;
+}
+
+/** Pagination query parameters. */
+export interface PaginationParams {
+  page?: number;
+  pageSize?: number;
+}
+
+/** Sort query parameters. */
+export interface SortParams {
+  sortBy?: string;
+  sortOrder?: 'asc' | 'desc';
+}

--- a/src/services/api/__tests__/claimApi.test.ts
+++ b/src/services/api/__tests__/claimApi.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for claimApi service module.
+ */
+
+import apiClient from '@/lib/api-client';
+import { claimApi } from '@/services/api/claimApi';
+
+jest.mock('@/lib/api-client', () => {
+  const mockClient = {
+    get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn(),
+    patch: jest.fn(),
+    delete: jest.fn(),
+    createCancelToken: jest.fn(() => ({ signal: new AbortController().signal })),
+    cancelRequest: jest.fn(),
+  };
+  return { __esModule: true, default: mockClient, apiClient: mockClient };
+});
+
+const mockedClient = apiClient as jest.Mocked<typeof apiClient>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('claimApi', () => {
+  describe('list', () => {
+    it('calls GET /api/claims with params and cancel token', async () => {
+      mockedClient.get.mockResolvedValue({
+        data: { items: [], totalCount: 0, page: 1, pageSize: 10, totalPages: 0 },
+        status: 200,
+        headers: new Headers(),
+      });
+
+      await claimApi.list({ status: 'Pending', page: 1 });
+
+      expect(mockedClient.createCancelToken).toHaveBeenCalledWith('claim-list');
+      expect(mockedClient.get).toHaveBeenCalledWith(
+        '/api/claims',
+        expect.objectContaining({
+          params: { status: 'Pending', page: 1 },
+          retries: 1,
+        })
+      );
+    });
+  });
+
+  describe('getById', () => {
+    it('calls GET /api/claims/:id', async () => {
+      const claim = { id: 'CLM-001', policyId: 'p1', status: 'Active' };
+      mockedClient.get.mockResolvedValue({ data: claim, status: 200, headers: new Headers() });
+
+      const result = await claimApi.getById('CLM-001');
+
+      expect(mockedClient.get).toHaveBeenCalledWith(
+        '/api/claims/CLM-001',
+        expect.anything()
+      );
+      expect(result.data).toEqual(claim);
+    });
+  });
+
+  describe('create', () => {
+    it('calls POST /api/claims with body', async () => {
+      const payload = {
+        policyId: 'p1',
+        incidentType: 'Wallet Hack',
+        amount: 5000,
+        description: 'Lost funds',
+      };
+      mockedClient.post.mockResolvedValue({
+        data: { id: 'CLM-NEW', ...payload, status: 'Pending' },
+        status: 201,
+        headers: new Headers(),
+      });
+
+      const result = await claimApi.create(payload);
+
+      expect(mockedClient.post).toHaveBeenCalledWith('/api/claims', payload, undefined);
+      expect(result.data).toMatchObject({ id: 'CLM-NEW' });
+    });
+  });
+
+  describe('update', () => {
+    it('calls PATCH /api/claims/:id with body', async () => {
+      mockedClient.patch.mockResolvedValue({
+        data: { id: 'CLM-001', status: 'Approved' },
+        status: 200,
+        headers: new Headers(),
+      });
+
+      await claimApi.update('CLM-001', { status: 'Approved' });
+
+      expect(mockedClient.patch).toHaveBeenCalledWith(
+        '/api/claims/CLM-001',
+        { status: 'Approved' },
+        undefined
+      );
+    });
+  });
+
+  describe('remove', () => {
+    it('calls DELETE /api/claims/:id', async () => {
+      mockedClient.delete.mockResolvedValue({ data: undefined, status: 204, headers: new Headers() });
+
+      await claimApi.remove('CLM-001');
+
+      expect(mockedClient.delete).toHaveBeenCalledWith('/api/claims/CLM-001', undefined);
+    });
+  });
+
+  describe('getStatistics', () => {
+    it('calls GET /api/claims/statistics', async () => {
+      mockedClient.get.mockResolvedValue({
+        data: { totalClaims: 5, pendingClaims: 2, approvedClaims: 3, totalClaimedAmount: 25000 },
+        status: 200,
+        headers: new Headers(),
+      });
+
+      const result = await claimApi.getStatistics();
+
+      expect(mockedClient.get).toHaveBeenCalledWith(
+        '/api/claims/statistics',
+        expect.objectContaining({ retries: 1 })
+      );
+      expect(result.data.totalClaims).toBe(5);
+    });
+  });
+
+  describe('cancelAll', () => {
+    it('cancels all claim-related requests', () => {
+      claimApi.cancelAll();
+
+      expect(mockedClient.cancelRequest).toHaveBeenCalledWith('claim-list');
+      expect(mockedClient.cancelRequest).toHaveBeenCalledWith('claim-detail');
+    });
+  });
+});

--- a/src/services/api/__tests__/daoApi.test.ts
+++ b/src/services/api/__tests__/daoApi.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for daoApi service module.
+ */
+
+import apiClient from '@/lib/api-client';
+import { daoApi } from '@/services/api/daoApi';
+
+jest.mock('@/lib/api-client', () => {
+  const mockClient = {
+    get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn(),
+    patch: jest.fn(),
+    delete: jest.fn(),
+    createCancelToken: jest.fn(() => ({ signal: new AbortController().signal })),
+    cancelRequest: jest.fn(),
+  };
+  return { __esModule: true, default: mockClient, apiClient: mockClient };
+});
+
+const mockedClient = apiClient as jest.Mocked<typeof apiClient>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('daoApi', () => {
+  describe('listProposals', () => {
+    it('calls GET /api/dao/proposals with params', async () => {
+      mockedClient.get.mockResolvedValue({
+        data: { items: [], totalCount: 0, page: 1, pageSize: 10, totalPages: 0 },
+        status: 200,
+        headers: new Headers(),
+      });
+
+      await daoApi.listProposals({ status: 'active', page: 1 });
+
+      expect(mockedClient.createCancelToken).toHaveBeenCalledWith('dao-proposal-list');
+      expect(mockedClient.get).toHaveBeenCalledWith(
+        '/api/dao/proposals',
+        expect.objectContaining({
+          params: { status: 'active', page: 1 },
+          retries: 1,
+        })
+      );
+    });
+  });
+
+  describe('getProposalById', () => {
+    it('calls GET /api/dao/proposals/:id', async () => {
+      const proposal = { id: 'PROP-001', title: 'Test Proposal' };
+      mockedClient.get.mockResolvedValue({ data: proposal, status: 200, headers: new Headers() });
+
+      const result = await daoApi.getProposalById('PROP-001');
+
+      expect(mockedClient.get).toHaveBeenCalledWith(
+        '/api/dao/proposals/PROP-001',
+        expect.anything()
+      );
+      expect(result.data).toEqual(proposal);
+    });
+  });
+
+  describe('createProposal', () => {
+    it('calls POST /api/dao/proposals with body', async () => {
+      const payload = {
+        title: 'New Proposal',
+        description: 'Description',
+        startDate: '2026-01-01',
+        endDate: '2026-01-31',
+      };
+      mockedClient.post.mockResolvedValue({
+        data: { id: 'PROP-NEW', ...payload },
+        status: 201,
+        headers: new Headers(),
+      });
+
+      const result = await daoApi.createProposal(payload);
+
+      expect(mockedClient.post).toHaveBeenCalledWith('/api/dao/proposals', payload, undefined);
+      expect(result.data).toMatchObject({ id: 'PROP-NEW' });
+    });
+  });
+
+  describe('castVote', () => {
+    it('calls POST /api/dao/proposals/:id/vote with vote type', async () => {
+      mockedClient.post.mockResolvedValue({
+        data: { success: true, updatedProposal: { id: 'PROP-001' } },
+        status: 200,
+        headers: new Headers(),
+      });
+
+      const result = await daoApi.castVote('PROP-001', 'for');
+
+      expect(mockedClient.post).toHaveBeenCalledWith(
+        '/api/dao/proposals/PROP-001/vote',
+        { vote: 'for' },
+        undefined
+      );
+      expect(result.data.success).toBe(true);
+    });
+
+    it('supports all vote types', async () => {
+      mockedClient.post.mockResolvedValue({
+        data: { success: true, updatedProposal: {} },
+        status: 200,
+        headers: new Headers(),
+      });
+
+      for (const vote of ['for', 'against', 'abstain'] as const) {
+        await daoApi.castVote('PROP-001', vote);
+      }
+
+      expect(mockedClient.post).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('getStatistics', () => {
+    it('calls GET /api/dao/statistics with retry', async () => {
+      mockedClient.get.mockResolvedValue({
+        data: { activeProposals: 3, votedProposals: 1, totalVotingPower: 250 },
+        status: 200,
+        headers: new Headers(),
+      });
+
+      const result = await daoApi.getStatistics();
+
+      expect(mockedClient.get).toHaveBeenCalledWith(
+        '/api/dao/statistics',
+        expect.objectContaining({ retries: 1 })
+      );
+      expect(result.data.activeProposals).toBe(3);
+    });
+  });
+
+  describe('cancelAll', () => {
+    it('cancels all DAO-related requests', () => {
+      daoApi.cancelAll();
+
+      expect(mockedClient.cancelRequest).toHaveBeenCalledWith('dao-proposal-list');
+      expect(mockedClient.cancelRequest).toHaveBeenCalledWith('dao-proposal-detail');
+    });
+  });
+});

--- a/src/services/api/__tests__/policyApi.test.ts
+++ b/src/services/api/__tests__/policyApi.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests for policyApi service module.
+ */
+
+import apiClient from '@/lib/api-client';
+import { policyApi } from '@/services/api/policyApi';
+
+// Mock the API client
+jest.mock('@/lib/api-client', () => {
+  const mockClient = {
+    get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn(),
+    patch: jest.fn(),
+    delete: jest.fn(),
+    createCancelToken: jest.fn(() => ({ signal: new AbortController().signal })),
+    cancelRequest: jest.fn(),
+  };
+  return { __esModule: true, default: mockClient, apiClient: mockClient };
+});
+
+const mockedClient = apiClient as jest.Mocked<typeof apiClient>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('policyApi', () => {
+  describe('list', () => {
+    it('calls GET /api/policies with params', async () => {
+      const mockResponse = {
+        data: { items: [], totalCount: 0, page: 1, pageSize: 10, totalPages: 0 },
+        status: 200,
+        headers: new Headers(),
+      };
+      mockedClient.get.mockResolvedValue(mockResponse);
+
+      const result = await policyApi.list({ status: 'active', page: 1 });
+
+      expect(mockedClient.get).toHaveBeenCalledWith(
+        '/api/policies',
+        expect.objectContaining({
+          params: { status: 'active', page: 1 },
+          retries: 1,
+        })
+      );
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('creates a cancel token for list requests', async () => {
+      mockedClient.get.mockResolvedValue({ data: {}, status: 200, headers: new Headers() });
+
+      await policyApi.list();
+
+      expect(mockedClient.createCancelToken).toHaveBeenCalledWith('policy-list');
+    });
+  });
+
+  describe('getById', () => {
+    it('calls GET /api/policies/:id', async () => {
+      const mockPolicy = { id: 'p1', name: 'Test Policy' };
+      mockedClient.get.mockResolvedValue({ data: mockPolicy, status: 200, headers: new Headers() });
+
+      const result = await policyApi.getById('p1');
+
+      expect(mockedClient.get).toHaveBeenCalledWith(
+        '/api/policies/p1',
+        expect.objectContaining({})
+      );
+      expect(result.data).toEqual(mockPolicy);
+    });
+
+    it('encodes special characters in ID', async () => {
+      mockedClient.get.mockResolvedValue({ data: {}, status: 200, headers: new Headers() });
+
+      await policyApi.getById('p/1');
+
+      expect(mockedClient.get).toHaveBeenCalledWith(
+        '/api/policies/p%2F1',
+        expect.anything()
+      );
+    });
+  });
+
+  describe('create', () => {
+    it('calls POST /api/policies with body', async () => {
+      const newPolicy = { name: 'New', type: 'Health' as const, coverageLimit: 50000 };
+      mockedClient.post.mockResolvedValue({ data: { id: 'p99', ...newPolicy }, status: 201, headers: new Headers() });
+
+      const result = await policyApi.create(newPolicy);
+
+      expect(mockedClient.post).toHaveBeenCalledWith('/api/policies', newPolicy, undefined);
+      expect(result.data).toMatchObject({ id: 'p99', name: 'New' });
+    });
+  });
+
+  describe('update', () => {
+    it('calls PUT /api/policies/:id with body', async () => {
+      mockedClient.put.mockResolvedValue({ data: { id: 'p1', name: 'Updated' }, status: 200, headers: new Headers() });
+
+      await policyApi.update('p1', { name: 'Updated' });
+
+      expect(mockedClient.put).toHaveBeenCalledWith(
+        '/api/policies/p1',
+        { name: 'Updated' },
+        undefined
+      );
+    });
+  });
+
+  describe('remove', () => {
+    it('calls DELETE /api/policies/:id', async () => {
+      mockedClient.delete.mockResolvedValue({ data: undefined, status: 204, headers: new Headers() });
+
+      await policyApi.remove('p1');
+
+      expect(mockedClient.delete).toHaveBeenCalledWith('/api/policies/p1', undefined);
+    });
+  });
+
+  describe('calculatePremium', () => {
+    it('calls POST /api/policies/premium', async () => {
+      const payload = { policyType: 'Health' as const, coverageLimit: 50000 };
+      mockedClient.post.mockResolvedValue({
+        data: { basePremium: 200, finalPremium: 250, riskMultiplier: 1.25, breakdown: {} },
+        status: 200,
+        headers: new Headers(),
+      });
+
+      await policyApi.calculatePremium(payload);
+
+      expect(mockedClient.post).toHaveBeenCalledWith(
+        '/api/policies/premium',
+        payload,
+        expect.objectContaining({})
+      );
+    });
+  });
+
+  describe('getStatistics', () => {
+    it('calls GET /api/policies/statistics with retry', async () => {
+      mockedClient.get.mockResolvedValue({
+        data: { totalPolicies: 10, activePolicies: 8, totalCoverage: 500000, averagePremium: 300 },
+        status: 200,
+        headers: new Headers(),
+      });
+
+      await policyApi.getStatistics();
+
+      expect(mockedClient.get).toHaveBeenCalledWith(
+        '/api/policies/statistics',
+        expect.objectContaining({ retries: 1 })
+      );
+    });
+  });
+
+  describe('cancelAll', () => {
+    it('cancels all policy-related requests', () => {
+      policyApi.cancelAll();
+
+      expect(mockedClient.cancelRequest).toHaveBeenCalledWith('policy-list');
+      expect(mockedClient.cancelRequest).toHaveBeenCalledWith('policy-detail');
+      expect(mockedClient.cancelRequest).toHaveBeenCalledWith('policy-premium');
+    });
+  });
+});

--- a/src/services/api/claimApi.ts
+++ b/src/services/api/claimApi.ts
@@ -1,0 +1,150 @@
+/**
+ * Claim API service module.
+ * Typed methods for all claim-related backend communication.
+ */
+
+import apiClient, { type ApiResponse, type RequestConfig } from '@/lib/api-client';
+import type { PaginatedResponse, PaginationParams, SortParams } from '@/lib/types/api.types';
+
+// ─── Claim types ─────────────────────────────────────────────────────────────
+
+export type ClaimStatus = 'Active' | 'Pending' | 'Approved' | 'Rejected';
+
+export interface Claim {
+  id: string;
+  policyId: string;
+  policyName: string;
+  incidentType: string;
+  amount: number;
+  amountFormatted: string;
+  dateFiled: string;
+  status: ClaimStatus;
+  description: string;
+  evidence?: string[];
+  walletAddress?: string;
+}
+
+export interface ClaimCreationRequest {
+  policyId: string;
+  incidentType: string;
+  amount: number;
+  description: string;
+  evidence?: string[];
+  walletAddress?: string;
+}
+
+export interface ClaimUpdateRequest {
+  status?: ClaimStatus;
+  description?: string;
+  evidence?: string[];
+}
+
+export interface ClaimListParams extends PaginationParams, SortParams {
+  status?: ClaimStatus;
+  policyId?: string;
+  search?: string;
+}
+
+// ─── Cancellation keys ──────────────────────────────────────────────────────
+
+const CANCEL_KEYS = {
+  list: 'claim-list',
+  detail: 'claim-detail',
+} as const;
+
+// ─── API Methods ─────────────────────────────────────────────────────────────
+
+export const claimApi = {
+  /**
+   * Fetch a paginated list of claims.
+   */
+  async list(
+    params?: ClaimListParams,
+    config?: RequestConfig
+  ): Promise<ApiResponse<PaginatedResponse<Claim>>> {
+    const controller = apiClient.createCancelToken(CANCEL_KEYS.list);
+    return apiClient.get<PaginatedResponse<Claim>>('/api/claims', {
+      params: params as Record<string, string | number | boolean | undefined>,
+      signal: controller.signal,
+      retries: 1,
+      ...config,
+    });
+  },
+
+  /**
+   * Fetch a single claim by ID.
+   */
+  async getById(
+    id: string,
+    config?: RequestConfig
+  ): Promise<ApiResponse<Claim>> {
+    const controller = apiClient.createCancelToken(CANCEL_KEYS.detail);
+    return apiClient.get<Claim>(`/api/claims/${encodeURIComponent(id)}`, {
+      signal: controller.signal,
+      ...config,
+    });
+  },
+
+  /**
+   * Submit a new claim.
+   */
+  async create(
+    data: ClaimCreationRequest,
+    config?: RequestConfig
+  ): Promise<ApiResponse<Claim>> {
+    return apiClient.post<Claim>('/api/claims', data, config);
+  },
+
+  /**
+   * Update an existing claim (e.g. add evidence, change status).
+   */
+  async update(
+    id: string,
+    data: ClaimUpdateRequest,
+    config?: RequestConfig
+  ): Promise<ApiResponse<Claim>> {
+    return apiClient.patch<Claim>(
+      `/api/claims/${encodeURIComponent(id)}`,
+      data,
+      config
+    );
+  },
+
+  /**
+   * Delete / withdraw a claim.
+   */
+  async remove(
+    id: string,
+    config?: RequestConfig
+  ): Promise<ApiResponse<void>> {
+    return apiClient.delete<void>(
+      `/api/claims/${encodeURIComponent(id)}`,
+      config
+    );
+  },
+
+  /**
+   * Fetch claim statistics for the current user.
+   */
+  async getStatistics(
+    config?: RequestConfig
+  ): Promise<
+    ApiResponse<{
+      totalClaims: number;
+      pendingClaims: number;
+      approvedClaims: number;
+      totalClaimedAmount: number;
+    }>
+  > {
+    return apiClient.get('/api/claims/statistics', { retries: 1, ...config });
+  },
+
+  /**
+   * Cancel any in-flight claim requests.
+   */
+  cancelAll(): void {
+    Object.values(CANCEL_KEYS).forEach((key) => apiClient.cancelRequest(key));
+  },
+};
+
+export default claimApi;

--- a/src/services/api/daoApi.ts
+++ b/src/services/api/daoApi.ts
@@ -1,0 +1,119 @@
+/**
+ * DAO API service module.
+ * Typed methods for governance proposals and voting.
+ */
+
+import apiClient, { type ApiResponse, type RequestConfig } from '@/lib/api-client';
+import type { PaginatedResponse, PaginationParams, SortParams } from '@/lib/types/api.types';
+import type { Proposal, VoteType } from '@/types/dao-types';
+
+// ─── Query types ─────────────────────────────────────────────────────────────
+
+export type ProposalStatus = 'active' | 'pending' | 'expired';
+
+export interface ProposalListParams extends PaginationParams, SortParams {
+  status?: ProposalStatus;
+  search?: string;
+}
+
+export interface CastVoteRequest {
+  proposalId: string;
+  vote: VoteType;
+}
+
+export interface CreateProposalRequest {
+  title: string;
+  description: string;
+  startDate: string;
+  endDate: string;
+}
+
+// ─── Cancellation keys ──────────────────────────────────────────────────────
+
+const CANCEL_KEYS = {
+  list: 'dao-proposal-list',
+  detail: 'dao-proposal-detail',
+} as const;
+
+// ─── API Methods ─────────────────────────────────────────────────────────────
+
+export const daoApi = {
+  /**
+   * Fetch a paginated list of proposals.
+   */
+  async listProposals(
+    params?: ProposalListParams,
+    config?: RequestConfig
+  ): Promise<ApiResponse<PaginatedResponse<Proposal>>> {
+    const controller = apiClient.createCancelToken(CANCEL_KEYS.list);
+    return apiClient.get<PaginatedResponse<Proposal>>('/api/dao/proposals', {
+      params: params as Record<string, string | number | boolean | undefined>,
+      signal: controller.signal,
+      retries: 1,
+      ...config,
+    });
+  },
+
+  /**
+   * Fetch a single proposal by ID.
+   */
+  async getProposalById(
+    id: string,
+    config?: RequestConfig
+  ): Promise<ApiResponse<Proposal>> {
+    const controller = apiClient.createCancelToken(CANCEL_KEYS.detail);
+    return apiClient.get<Proposal>(
+      `/api/dao/proposals/${encodeURIComponent(id)}`,
+      { signal: controller.signal, ...config }
+    );
+  },
+
+  /**
+   * Create a new governance proposal.
+   */
+  async createProposal(
+    data: CreateProposalRequest,
+    config?: RequestConfig
+  ): Promise<ApiResponse<Proposal>> {
+    return apiClient.post<Proposal>('/api/dao/proposals', data, config);
+  },
+
+  /**
+   * Cast a vote on a proposal.
+   */
+  async castVote(
+    proposalId: string,
+    vote: VoteType,
+    config?: RequestConfig
+  ): Promise<ApiResponse<{ success: boolean; updatedProposal: Proposal }>> {
+    return apiClient.post(
+      `/api/dao/proposals/${encodeURIComponent(proposalId)}/vote`,
+      { vote },
+      config
+    );
+  },
+
+  /**
+   * Fetch governance statistics for the current user.
+   */
+  async getStatistics(
+    config?: RequestConfig
+  ): Promise<
+    ApiResponse<{
+      activeProposals: number;
+      votedProposals: number;
+      totalVotingPower: number;
+    }>
+  > {
+    return apiClient.get('/api/dao/statistics', { retries: 1, ...config });
+  },
+
+  /**
+   * Cancel any in-flight DAO requests.
+   */
+  cancelAll(): void {
+    Object.values(CANCEL_KEYS).forEach((key) => apiClient.cancelRequest(key));
+  },
+};
+
+export default daoApi;

--- a/src/services/api/index.ts
+++ b/src/services/api/index.ts
@@ -1,0 +1,27 @@
+/**
+ * API service barrel export.
+ * Import individual services from here for clean, centralized access.
+ *
+ * @example
+ *   import { policyApi, claimApi, daoApi } from '@/services/api';
+ */
+
+export { policyApi } from './policyApi';
+export { claimApi } from './claimApi';
+export { daoApi } from './daoApi';
+
+// Re-export useful types
+export type { PolicyListParams } from './policyApi';
+export type {
+  Claim,
+  ClaimCreationRequest,
+  ClaimUpdateRequest,
+  ClaimListParams,
+  ClaimStatus,
+} from './claimApi';
+export type {
+  ProposalListParams,
+  ProposalStatus,
+  CastVoteRequest,
+  CreateProposalRequest,
+} from './daoApi';

--- a/src/services/api/policyApi.ts
+++ b/src/services/api/policyApi.ts
@@ -1,0 +1,145 @@
+/**
+ * Policy API service module.
+ * Typed methods for all policy-related backend communication.
+ */
+
+import apiClient, { type ApiResponse, type RequestConfig } from '@/lib/api-client';
+import type { PaginatedResponse, PaginationParams, SortParams } from '@/lib/types/api.types';
+import type {
+  Policy,
+  PolicyCreationRequest,
+  PolicyUpdateRequest,
+  PolicyFilterOptions,
+  PremiumCalculationRequest,
+  PremiumCalculationResult,
+  PolicyStatus,
+  PolicyType,
+} from '@/services/types/policy.types';
+
+// ─── Query types ─────────────────────────────────────────────────────────────
+
+export interface PolicyListParams extends PaginationParams, SortParams {
+  status?: PolicyStatus;
+  type?: PolicyType;
+  search?: string;
+}
+
+// ─── Cancellation keys ──────────────────────────────────────────────────────
+
+const CANCEL_KEYS = {
+  list: 'policy-list',
+  detail: 'policy-detail',
+  premium: 'policy-premium',
+} as const;
+
+// ─── API Methods ─────────────────────────────────────────────────────────────
+
+export const policyApi = {
+  /**
+   * Fetch a paginated, filterable list of policies.
+   */
+  async list(
+    params?: PolicyListParams,
+    config?: RequestConfig
+  ): Promise<ApiResponse<PaginatedResponse<Policy>>> {
+    const controller = apiClient.createCancelToken(CANCEL_KEYS.list);
+    return apiClient.get<PaginatedResponse<Policy>>('/api/policies', {
+      params: params as Record<string, string | number | boolean | undefined>,
+      signal: controller.signal,
+      retries: 1,
+      ...config,
+    });
+  },
+
+  /**
+   * Fetch a single policy by ID.
+   */
+  async getById(
+    id: string,
+    config?: RequestConfig
+  ): Promise<ApiResponse<Policy>> {
+    const controller = apiClient.createCancelToken(CANCEL_KEYS.detail);
+    return apiClient.get<Policy>(`/api/policies/${encodeURIComponent(id)}`, {
+      signal: controller.signal,
+      ...config,
+    });
+  },
+
+  /**
+   * Create a new policy.
+   */
+  async create(
+    data: PolicyCreationRequest,
+    config?: RequestConfig
+  ): Promise<ApiResponse<Policy>> {
+    return apiClient.post<Policy>('/api/policies', data, config);
+  },
+
+  /**
+   * Update an existing policy.
+   */
+  async update(
+    id: string,
+    data: PolicyUpdateRequest,
+    config?: RequestConfig
+  ): Promise<ApiResponse<Policy>> {
+    return apiClient.put<Policy>(
+      `/api/policies/${encodeURIComponent(id)}`,
+      data,
+      config
+    );
+  },
+
+  /**
+   * Delete a policy.
+   */
+  async remove(
+    id: string,
+    config?: RequestConfig
+  ): Promise<ApiResponse<void>> {
+    return apiClient.delete<void>(
+      `/api/policies/${encodeURIComponent(id)}`,
+      config
+    );
+  },
+
+  /**
+   * Calculate premium for policy parameters.
+   */
+  async calculatePremium(
+    data: PremiumCalculationRequest,
+    config?: RequestConfig
+  ): Promise<ApiResponse<PremiumCalculationResult>> {
+    const controller = apiClient.createCancelToken(CANCEL_KEYS.premium);
+    return apiClient.post<PremiumCalculationResult>(
+      '/api/policies/premium',
+      data,
+      { signal: controller.signal, ...config }
+    );
+  },
+
+  /**
+   * Fetch aggregate policy statistics.
+   */
+  async getStatistics(
+    config?: RequestConfig
+  ): Promise<
+    ApiResponse<{
+      totalPolicies: number;
+      activePolicies: number;
+      totalCoverage: number;
+      averagePremium: number;
+    }>
+  > {
+    return apiClient.get('/api/policies/statistics', { retries: 1, ...config });
+  },
+
+  /**
+   * Cancel any in-flight policy requests.
+   */
+  cancelAll(): void {
+    Object.values(CANCEL_KEYS).forEach((key) => apiClient.cancelRequest(key));
+  },
+};
+
+export default policyApi;


### PR DESCRIPTION
## Summary

Resolves #100 — The application lacked a centralized API service layer for backend communication. Components and hooks would need to make direct fetch/axios calls, leading to scattered API logic, no centralized error handling, and no retry mechanisms. This PR adds a complete API abstraction layer with typed service modules for every resource domain.

## Changes

### New Files

- **`src/lib/api-client.ts`** — Centralized API client built on native `fetch`:
  - Request/response/error interceptor chains (add/remove dynamically)
  - Auth token interceptor (reads JWT from persisted wallet store)
  - Error categorization interceptor (routes to existing `errorHandler`)
  - Retry logic with exponential backoff via `errorHandler.retryWithBackoff`
  - Request cancellation with `AbortController` (per-key tracking, `cancelAll()`)
  - Configurable timeout (default 30s)
  - Query parameter serialization with undefined filtering
  - Typed `ApiResponse<T>`, `ApiClientError`, and `RequestConfig`
  - Uses `NEXT_PUBLIC_API_BASE_URL` environment variable

- **`src/lib/types/api.types.ts`** — Shared API response types:
  - `PaginatedResponse<T>`, `SingleResponse<T>`, `PaginationParams`, `SortParams`

- **`src/services/api/policyApi.ts`** — Typed policy service module:
  - `list()`, `getById()`, `create()`, `update()`, `remove()`, `calculatePremium()`, `getStatistics()`, `cancelAll()`

- **`src/services/api/claimApi.ts`** — Typed claim service module:
  - `list()`, `getById()`, `create()`, `update()`, `remove()`, `getStatistics()`, `cancelAll()`

- **`src/services/api/daoApi.ts`** — Typed DAO governance service module:
  - `listProposals()`, `getProposalById()`, `createProposal()`, `castVote()`, `getStatistics()`, `cancelAll()`

- **`src/services/api/index.ts`** — Barrel export for clean imports

### Tests (45 tests, all passing)
- **`src/lib/__tests__/api-client.test.ts`** — 21 tests: HTTP methods (GET/POST/PUT/PATCH/DELETE), query params, error handling (4xx/5xx/network/abort), request interceptors, auth interceptor, response interceptors, error interceptors, interceptor removal, request cancellation, retry logic, 204 handling
- **`src/services/api/__tests__/policyApi.test.ts`** — 10 tests
- **`src/services/api/__tests__/claimApi.test.ts`** — 7 tests
- **`src/services/api/__tests__/daoApi.test.ts`** — 7 tests

## Issue Tasks Addressed

- [x] Create `src/lib/api-client.ts` with fetch wrapper
- [x] Implement request interceptors for auth tokens
- [x] Add response interceptors for standardized error handling
- [x] Create typed API methods for each resource (policies, claims, proposals)
- [x] Add retry logic using existing `errorHandler.retryWithBackoff`
- [x] Implement request cancellation for cleanup
- [x] Add TypeScript types for all API responses
- [x] Create API service modules: `policyApi.ts`, `claimApi.ts`, `daoApi.ts`
- [x] Add comprehensive tests with mocked API calls

## Usage Example

```typescript
import { policyApi, claimApi, daoApi } from '@/services/api';

// Fetch policies with filtering
const { data } = await policyApi.list({ status: 'active', page: 1 });

// Submit a claim
const { data: claim } = await claimApi.create({
  policyId: 'p1',
  incidentType: 'wallet-hack',
  amount: 5000,
  description: 'Lost funds in breach',
});

// Cast a vote
await daoApi.castVote('PROP-001', 'for');

// Cancel in-flight requests on unmount
useEffect(() => () => policyApi.cancelAll(), []);
```

## Testing

```bash
npm test -- --testPathPattern="(lib/__tests__/api-client|services/api/__tests__)"
# 45 tests, 4 suites — all passing
```
