### PR TITLE
feat: Add Centralized Configuration Management System

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# ─── Stellar Insured – Environment Variables ────────────────────────────────
+# Copy this file to .env.local and fill in the values for your environment.
+# Variables prefixed with NEXT_PUBLIC_ are exposed to the browser.
+
+# ─── Application ─────────────────────────────────────────────────────────────
+NEXT_PUBLIC_APP_NAME="Stellar Insured"
+NEXT_PUBLIC_APP_ENV=development          # development | staging | production
+
+# ─── Backend API ─────────────────────────────────────────────────────────────
+NEXT_PUBLIC_API_BASE_URL=http://localhost:4000
+
+# ─── Stellar Network ─────────────────────────────────────────────────────────
+NEXT_PUBLIC_STELLAR_NETWORK=testnet      # testnet | mainnet
+
+# Override the default Horizon / Explorer URLs (optional – derived from network)
+# NEXT_PUBLIC_HORIZON_URL=https://horizon-testnet.stellar.org
+# NEXT_PUBLIC_EXPLORER_URL=https://stellar.expert/explorer/testnet

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # env files (can opt-in for committing if needed)
-.env*
+.env
 
 # vercel
 .vercel

--- a/src/config/__tests__/api.test.ts
+++ b/src/config/__tests__/api.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Tests for API configuration.
+ */
+
+describe('api config', () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  beforeEach(() => {
+    jest.resetModules();
+    Object.keys(process.env).forEach((key) => {
+      if (key.startsWith('NEXT_PUBLIC_')) {
+        delete process.env[key];
+      }
+    });
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  function loadApiConfig() {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    return require('@/config/api') as typeof import('@/config/api');
+  }
+
+  it('uses default baseUrl when env var not set', () => {
+    const { apiConfig } = loadApiConfig();
+    expect(apiConfig.baseUrl).toBe('http://localhost:4000');
+  });
+
+  it('uses env var when NEXT_PUBLIC_API_BASE_URL is set', () => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = 'https://api.example.com';
+    const { apiConfig } = loadApiConfig();
+    expect(apiConfig.baseUrl).toBe('https://api.example.com');
+  });
+
+  it('has a default timeout of 30 seconds', () => {
+    const { apiConfig } = loadApiConfig();
+    expect(apiConfig.timeout).toBe(30_000);
+  });
+
+  it('has default retries of 0', () => {
+    const { apiConfig } = loadApiConfig();
+    expect(apiConfig.retries).toBe(0);
+  });
+
+  it('has the correct wallet store key', () => {
+    const { apiConfig } = loadApiConfig();
+    expect(apiConfig.walletStoreKey).toBe('wallet-store');
+  });
+});

--- a/src/config/__tests__/constants.test.ts
+++ b/src/config/__tests__/constants.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Tests for application constants.
+ */
+
+import {
+  NETWORK_POLL_INTERVAL,
+  BALANCE_POLL_INTERVAL,
+  FILTER_DEBOUNCE_DELAY,
+  COPY_FEEDBACK_TIMEOUT,
+  FORM_SUBMIT_TIMEOUT,
+  SESSION_STORAGE_KEY,
+  WALLET_STORE_KEY,
+  DEFAULT_PREMIUM_MIN,
+  DEFAULT_PREMIUM_MAX,
+  DEFAULT_DEDUCTIBLE_MIN,
+  DEFAULT_DEDUCTIBLE_MAX,
+  FREIGHTER_CHUNK_SIZE,
+  FIXED_PROCESSING_FEE,
+} from '@/config/constants';
+
+describe('constants', () => {
+  describe('polling & timeouts', () => {
+    it('NETWORK_POLL_INTERVAL is 5 seconds', () => {
+      expect(NETWORK_POLL_INTERVAL).toBe(5_000);
+    });
+
+    it('BALANCE_POLL_INTERVAL is 30 seconds', () => {
+      expect(BALANCE_POLL_INTERVAL).toBe(30_000);
+    });
+
+    it('FILTER_DEBOUNCE_DELAY is 300ms', () => {
+      expect(FILTER_DEBOUNCE_DELAY).toBe(300);
+    });
+
+    it('COPY_FEEDBACK_TIMEOUT is 2 seconds', () => {
+      expect(COPY_FEEDBACK_TIMEOUT).toBe(2_000);
+    });
+
+    it('FORM_SUBMIT_TIMEOUT is 3 seconds', () => {
+      expect(FORM_SUBMIT_TIMEOUT).toBe(3_000);
+    });
+  });
+
+  describe('storage keys', () => {
+    it('SESSION_STORAGE_KEY matches expected value', () => {
+      expect(SESSION_STORAGE_KEY).toBe('stellar_insured_session');
+    });
+
+    it('WALLET_STORE_KEY matches expected value', () => {
+      expect(WALLET_STORE_KEY).toBe('wallet-store');
+    });
+  });
+
+  describe('filter defaults', () => {
+    it('premium range defaults are correct', () => {
+      expect(DEFAULT_PREMIUM_MIN).toBe(0);
+      expect(DEFAULT_PREMIUM_MAX).toBe(1_000);
+    });
+
+    it('deductible range defaults are correct', () => {
+      expect(DEFAULT_DEDUCTIBLE_MIN).toBe(0);
+      expect(DEFAULT_DEDUCTIBLE_MAX).toBe(10_000);
+    });
+  });
+
+  describe('misc', () => {
+    it('FREIGHTER_CHUNK_SIZE is 32768 bytes', () => {
+      expect(FREIGHTER_CHUNK_SIZE).toBe(32768);
+    });
+
+    it('FIXED_PROCESSING_FEE is 50', () => {
+      expect(FIXED_PROCESSING_FEE).toBe(50);
+    });
+  });
+});

--- a/src/config/__tests__/env.test.ts
+++ b/src/config/__tests__/env.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for environment variable validation and access.
+ */
+
+describe('env', () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  beforeEach(() => {
+    jest.resetModules();
+    // Clear all NEXT_PUBLIC_ vars so each test starts clean
+    Object.keys(process.env).forEach((key) => {
+      if (key.startsWith('NEXT_PUBLIC_')) {
+        delete process.env[key];
+      }
+    });
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  function loadEnv() {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    return require('@/config/env') as typeof import('@/config/env');
+  }
+
+  // ─── validateEnv ────────────────────────────────────────────────────────
+
+  describe('validateEnv', () => {
+    it('returns valid when no required vars are missing', () => {
+      const { validateEnv } = loadEnv();
+      const result = validateEnv();
+      // By default all vars in schema are optional
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+  });
+
+  // ─── getEnv ─────────────────────────────────────────────────────────────
+
+  describe('getEnv', () => {
+    it('returns default for NEXT_PUBLIC_API_BASE_URL when not set', () => {
+      const { getEnv } = loadEnv();
+      expect(getEnv('NEXT_PUBLIC_API_BASE_URL')).toBe('http://localhost:4000');
+    });
+
+    it('returns env var value when set', () => {
+      process.env.NEXT_PUBLIC_API_BASE_URL = 'https://api.prod.example.com';
+      const { getEnv } = loadEnv();
+      expect(getEnv('NEXT_PUBLIC_API_BASE_URL')).toBe('https://api.prod.example.com');
+    });
+
+    it('returns default for NEXT_PUBLIC_STELLAR_NETWORK when not set', () => {
+      const { getEnv } = loadEnv();
+      expect(getEnv('NEXT_PUBLIC_STELLAR_NETWORK')).toBe('testnet');
+    });
+
+    it('returns mainnet when NEXT_PUBLIC_STELLAR_NETWORK is set', () => {
+      process.env.NEXT_PUBLIC_STELLAR_NETWORK = 'mainnet';
+      const { getEnv } = loadEnv();
+      expect(getEnv('NEXT_PUBLIC_STELLAR_NETWORK')).toBe('mainnet');
+    });
+
+    it('returns default for NEXT_PUBLIC_APP_NAME when not set', () => {
+      const { getEnv } = loadEnv();
+      expect(getEnv('NEXT_PUBLIC_APP_NAME')).toBe('Stellar Insured');
+    });
+
+    it('returns default for NEXT_PUBLIC_APP_ENV when not set', () => {
+      const { getEnv } = loadEnv();
+      expect(getEnv('NEXT_PUBLIC_APP_ENV')).toBe('development');
+    });
+
+    it('returns empty string for unknown keys', () => {
+      const { getEnv } = loadEnv();
+      expect(getEnv('TOTALLY_UNKNOWN_KEY')).toBe('');
+    });
+  });
+
+  // ─── getEnvSchema ───────────────────────────────────────────────────────
+
+  describe('getEnvSchema', () => {
+    it('returns the full schema array', () => {
+      const { getEnvSchema } = loadEnv();
+      const schema = getEnvSchema();
+      expect(Array.isArray(schema)).toBe(true);
+      expect(schema.length).toBeGreaterThanOrEqual(6);
+      expect(schema[0]).toHaveProperty('key');
+      expect(schema[0]).toHaveProperty('required');
+      expect(schema[0]).toHaveProperty('description');
+    });
+
+    it('every entry has a description', () => {
+      const { getEnvSchema } = loadEnv();
+      for (const entry of getEnvSchema()) {
+        expect(entry.description.length).toBeGreaterThan(0);
+      }
+    });
+  });
+});

--- a/src/config/__tests__/index.test.ts
+++ b/src/config/__tests__/index.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for the unified config barrel export.
+ */
+
+describe('config', () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  beforeEach(() => {
+    jest.resetModules();
+    Object.keys(process.env).forEach((key) => {
+      if (key.startsWith('NEXT_PUBLIC_')) {
+        delete process.env[key];
+      }
+    });
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  function loadConfig() {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    return require('@/config') as typeof import('@/config');
+  }
+
+  it('exports a unified config object', () => {
+    const { config } = loadConfig();
+    expect(config).toHaveProperty('app');
+    expect(config).toHaveProperty('stellar');
+    expect(config).toHaveProperty('api');
+    expect(config).toHaveProperty('constants');
+  });
+
+  it('config.app has correct defaults', () => {
+    const { config } = loadConfig();
+    expect(config.app.name).toBe('Stellar Insured');
+    expect(config.app.env).toBe('development');
+    expect(config.app.isDev).toBe(true);
+    expect(config.app.isProd).toBe(false);
+  });
+
+  it('config.app.isProd is true in production', () => {
+    process.env.NEXT_PUBLIC_APP_ENV = 'production';
+    const { config } = loadConfig();
+    expect(config.app.isProd).toBe(true);
+    expect(config.app.isDev).toBe(false);
+  });
+
+  it('config.stellar matches stellarConfig', () => {
+    const { config, stellarConfig } = loadConfig();
+    expect(config.stellar).toEqual(stellarConfig);
+  });
+
+  it('config.api matches apiConfig', () => {
+    const { config, apiConfig } = loadConfig();
+    expect(config.api).toEqual(apiConfig);
+  });
+
+  it('exports validateEnv function', () => {
+    const { validateEnv } = loadConfig();
+    expect(typeof validateEnv).toBe('function');
+    const result = validateEnv();
+    expect(result).toHaveProperty('valid');
+    expect(result).toHaveProperty('errors');
+  });
+
+  it('exports getEnv function', () => {
+    const { getEnv } = loadConfig();
+    expect(typeof getEnv).toBe('function');
+    expect(getEnv('NEXT_PUBLIC_APP_NAME')).toBe('Stellar Insured');
+  });
+
+  it('exports constants', () => {
+    const mod = loadConfig();
+    expect(mod.NETWORK_POLL_INTERVAL).toBe(5_000);
+    expect(mod.SESSION_STORAGE_KEY).toBe('stellar_insured_session');
+  });
+});

--- a/src/config/__tests__/stellar.test.ts
+++ b/src/config/__tests__/stellar.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for Stellar network configuration.
+ */
+
+describe('stellar config', () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  beforeEach(() => {
+    jest.resetModules();
+    Object.keys(process.env).forEach((key) => {
+      if (key.startsWith('NEXT_PUBLIC_')) {
+        delete process.env[key];
+      }
+    });
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  function loadStellarConfig() {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    return require('@/config/stellar') as typeof import('@/config/stellar');
+  }
+
+  describe('default (testnet)', () => {
+    it('uses testnet Horizon URL', () => {
+      const { stellarConfig } = loadStellarConfig();
+      expect(stellarConfig.horizonUrl).toBe('https://horizon-testnet.stellar.org');
+    });
+
+    it('uses testnet network passphrase', () => {
+      const { stellarConfig } = loadStellarConfig();
+      expect(stellarConfig.networkPassphrase).toBe('Test SDF Network ; September 2015');
+    });
+
+    it('uses testnet explorer URL', () => {
+      const { stellarConfig } = loadStellarConfig();
+      expect(stellarConfig.explorerUrl).toContain('testnet');
+    });
+
+    it('has correct networkId', () => {
+      const { stellarConfig } = loadStellarConfig();
+      expect(stellarConfig.networkId).toBe('testnet');
+    });
+
+    it('provides valid tx explorer path', () => {
+      const { stellarConfig } = loadStellarConfig();
+      expect(stellarConfig.explorerTxPath).toContain('/tx');
+    });
+
+    it('provides valid account explorer path', () => {
+      const { stellarConfig } = loadStellarConfig();
+      expect(stellarConfig.explorerAccountPath).toContain('/account');
+    });
+  });
+
+  describe('mainnet', () => {
+    it('switches to mainnet when env var is set', () => {
+      process.env.NEXT_PUBLIC_STELLAR_NETWORK = 'mainnet';
+      const { stellarConfig } = loadStellarConfig();
+      expect(stellarConfig.networkId).toBe('mainnet');
+      expect(stellarConfig.horizonUrl).toBe('https://horizon.stellar.org');
+      expect(stellarConfig.networkPassphrase).toBe(
+        'Public Global Stellar Network ; September 2015'
+      );
+    });
+
+    it('uses public explorer for mainnet', () => {
+      process.env.NEXT_PUBLIC_STELLAR_NETWORK = 'mainnet';
+      const { stellarConfig } = loadStellarConfig();
+      expect(stellarConfig.explorerUrl).toContain('public');
+    });
+  });
+
+  describe('custom overrides', () => {
+    it('uses custom Horizon URL when provided', () => {
+      process.env.NEXT_PUBLIC_HORIZON_URL = 'https://custom-horizon.example.com';
+      const { stellarConfig } = loadStellarConfig();
+      expect(stellarConfig.horizonUrl).toBe('https://custom-horizon.example.com');
+    });
+
+    it('uses custom Explorer URL when provided', () => {
+      process.env.NEXT_PUBLIC_EXPLORER_URL = 'https://custom-explorer.example.com';
+      const { stellarConfig } = loadStellarConfig();
+      expect(stellarConfig.explorerUrl).toBe('https://custom-explorer.example.com');
+      expect(stellarConfig.explorerTxPath).toBe('https://custom-explorer.example.com/tx');
+      expect(stellarConfig.explorerAccountPath).toBe('https://custom-explorer.example.com/account');
+    });
+
+    it('falls back to testnet for unknown network value', () => {
+      process.env.NEXT_PUBLIC_STELLAR_NETWORK = 'invalidnet';
+      const { stellarConfig } = loadStellarConfig();
+      expect(stellarConfig.networkId).toBe('testnet');
+    });
+  });
+});

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -1,0 +1,23 @@
+/**
+ * API and HTTP client configuration constants.
+ */
+
+import { getEnv } from './env';
+
+export interface ApiConfig {
+  /** Backend REST API base URL. */
+  baseUrl: string;
+  /** Default request timeout in milliseconds. */
+  timeout: number;
+  /** Default number of automatic retries for failed requests. */
+  retries: number;
+  /** localStorage key where the persisted wallet store lives. */
+  walletStoreKey: string;
+}
+
+export const apiConfig: ApiConfig = {
+  baseUrl: getEnv('NEXT_PUBLIC_API_BASE_URL'),
+  timeout: 30_000,
+  retries: 0,
+  walletStoreKey: 'wallet-store',
+};

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,0 +1,30 @@
+/**
+ * Application-wide constants – timeouts, polling intervals, storage keys,
+ * UI limits, and other magic numbers that were previously scattered
+ * throughout the codebase.
+ */
+
+// ─── Polling & Timeouts (ms) ─────────────────────────────────────────────────
+
+export const NETWORK_POLL_INTERVAL   = 5_000;   // stellar.ts network-change polling
+export const BALANCE_POLL_INTERVAL   = 30_000;  // useWalletBalance refresh
+export const FILTER_DEBOUNCE_DELAY   = 300;     // usePolicyFilters search debounce
+export const COPY_FEEDBACK_TIMEOUT   = 2_000;   // "Copied!" tooltip display duration
+export const FORM_SUBMIT_TIMEOUT     = 3_000;   // multi-step / claim form redirect delay
+
+// ─── Storage Keys ────────────────────────────────────────────────────────────
+
+export const SESSION_STORAGE_KEY     = 'stellar_insured_session';
+export const WALLET_STORE_KEY        = 'wallet-store';
+
+// ─── Pagination & Filtering Defaults ─────────────────────────────────────────
+
+export const DEFAULT_PREMIUM_MIN     = 0;
+export const DEFAULT_PREMIUM_MAX     = 1_000;
+export const DEFAULT_DEDUCTIBLE_MIN  = 0;
+export const DEFAULT_DEDUCTIBLE_MAX  = 10_000;
+
+// ─── Misc ────────────────────────────────────────────────────────────────────
+
+export const FREIGHTER_CHUNK_SIZE    = 0x8000;   // 32 768 bytes – message signing chunk
+export const FIXED_PROCESSING_FEE   = 50;        // policyService fee constant

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,0 +1,113 @@
+/**
+ * Environment variable validation and access layer.
+ *
+ * Call `validateEnv()` at app startup (e.g. in root layout) to assert
+ * that every required variable is present. Individual getters provide
+ * typed, defaulted access everywhere else.
+ */
+
+// ─── Schema ──────────────────────────────────────────────────────────────────
+
+interface EnvVarDef {
+  /** The NEXT_PUBLIC_ or server-only key name. */
+  key: string;
+  /** If true the app will refuse to boot without it. */
+  required: boolean;
+  /** Fallback used when the value is not set and not required. */
+  defaultValue?: string;
+  /** Human-readable description for docs / error messages. */
+  description: string;
+}
+
+const ENV_SCHEMA: EnvVarDef[] = [
+  // ── Public (available in browser) ─────────────────────────────────────
+  {
+    key: 'NEXT_PUBLIC_API_BASE_URL',
+    required: false,
+    defaultValue: 'http://localhost:4000',
+    description: 'Base URL for the backend REST API',
+  },
+  {
+    key: 'NEXT_PUBLIC_STELLAR_NETWORK',
+    required: false,
+    defaultValue: 'testnet',
+    description: 'Stellar network to connect to (testnet | mainnet)',
+  },
+  {
+    key: 'NEXT_PUBLIC_HORIZON_URL',
+    required: false,
+    defaultValue: '',                       // resolved per-network in stellar config
+    description: 'Custom Stellar Horizon server URL (overrides network default)',
+  },
+  {
+    key: 'NEXT_PUBLIC_EXPLORER_URL',
+    required: false,
+    defaultValue: '',                       // resolved per-network in stellar config
+    description: 'Custom Stellar block-explorer base URL',
+  },
+  {
+    key: 'NEXT_PUBLIC_APP_NAME',
+    required: false,
+    defaultValue: 'Stellar Insured',
+    description: 'Application display name',
+  },
+  {
+    key: 'NEXT_PUBLIC_APP_ENV',
+    required: false,
+    defaultValue: 'development',
+    description: 'Application environment (development | staging | production)',
+  },
+];
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function readEnv(key: string): string | undefined {
+  if (typeof process !== 'undefined' && process.env) {
+    return process.env[key];
+  }
+  return undefined;
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+export interface EnvValidationError {
+  key: string;
+  description: string;
+}
+
+export interface EnvValidationResult {
+  valid: boolean;
+  errors: EnvValidationError[];
+}
+
+/**
+ * Validate that all required environment variables are present.
+ * Returns a result object — does **not** throw so callers can decide
+ * how to surface errors.
+ */
+export function validateEnv(): EnvValidationResult {
+  const errors: EnvValidationError[] = [];
+
+  for (const def of ENV_SCHEMA) {
+    if (def.required && !readEnv(def.key)) {
+      errors.push({ key: def.key, description: def.description });
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Get a typed env value with its default already applied.
+ */
+export function getEnv(key: string): string {
+  const def = ENV_SCHEMA.find((d) => d.key === key);
+  return readEnv(key) ?? def?.defaultValue ?? '';
+}
+
+/**
+ * Return the full schema (useful for docs / dev tooling).
+ */
+export function getEnvSchema(): readonly EnvVarDef[] {
+  return ENV_SCHEMA;
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,0 +1,60 @@
+/**
+ * Centralized configuration management for Stellar Insured.
+ *
+ * Import from `@/config` everywhere instead of reaching for
+ * `process.env` or hard-coding values.
+ *
+ * @example
+ *   import { config } from '@/config';
+ *
+ *   const server = new Horizon.Server(config.stellar.horizonUrl);
+ *   const timeout = config.app.env === 'production' ? 60_000 : 30_000;
+ */
+
+import { getEnv, validateEnv, getEnvSchema } from './env';
+import { stellarConfig } from './stellar';
+import { apiConfig } from './api';
+import * as constants from './constants';
+
+// Re-export individual modules for granular imports
+export { validateEnv, getEnv, getEnvSchema } from './env';
+export { stellarConfig } from './stellar';
+export { apiConfig } from './api';
+export * from './constants';
+
+// Re-export types
+export type { EnvValidationResult, EnvValidationError } from './env';
+export type { StellarNetworkId, StellarNetworkConfig } from './stellar';
+export type { ApiConfig } from './api';
+
+// ─── Unified config object ──────────────────────────────────────────────────
+
+export interface AppConfig {
+  /** Application metadata. */
+  app: {
+    name: string;
+    env: string;
+    isDev: boolean;
+    isProd: boolean;
+  };
+  /** Stellar blockchain settings. */
+  stellar: typeof stellarConfig;
+  /** Backend API settings. */
+  api: typeof apiConfig;
+  /** Application-wide constants. */
+  constants: typeof constants;
+}
+
+export const config: AppConfig = {
+  app: {
+    name: getEnv('NEXT_PUBLIC_APP_NAME'),
+    env: getEnv('NEXT_PUBLIC_APP_ENV'),
+    isDev: getEnv('NEXT_PUBLIC_APP_ENV') === 'development',
+    isProd: getEnv('NEXT_PUBLIC_APP_ENV') === 'production',
+  },
+  stellar: stellarConfig,
+  api: apiConfig,
+  constants,
+};
+
+export default config;

--- a/src/config/stellar.ts
+++ b/src/config/stellar.ts
@@ -1,0 +1,75 @@
+/**
+ * Stellar network configuration.
+ *
+ * Centralises Horizon endpoints, explorer URLs, network passphrases,
+ * and asset-issuer addresses so that switching between testnet and
+ * mainnet requires only one env-var change.
+ */
+
+import { getEnv } from './env';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type StellarNetworkId = 'testnet' | 'mainnet';
+
+export interface StellarNetworkConfig {
+  /** "testnet" or "mainnet". */
+  networkId: StellarNetworkId;
+  /** Stellar network passphrase used for signing. */
+  networkPassphrase: string;
+  /** Horizon API endpoint. */
+  horizonUrl: string;
+  /** Block-explorer base URL (no trailing slash). */
+  explorerUrl: string;
+  /** Stellar-expert explorer for transaction links. */
+  explorerTxPath: string;
+  /** Stellar-expert explorer for account links. */
+  explorerAccountPath: string;
+}
+
+// ─── Per-network defaults ────────────────────────────────────────────────────
+
+const NETWORK_PRESETS: Record<StellarNetworkId, StellarNetworkConfig> = {
+  testnet: {
+    networkId: 'testnet',
+    networkPassphrase: 'Test SDF Network ; September 2015',
+    horizonUrl: 'https://horizon-testnet.stellar.org',
+    explorerUrl: 'https://stellar.expert/explorer/testnet',
+    explorerTxPath: 'https://stellar.expert/explorer/testnet/tx',
+    explorerAccountPath: 'https://stellar.expert/explorer/testnet/account',
+  },
+  mainnet: {
+    networkId: 'mainnet',
+    networkPassphrase: 'Public Global Stellar Network ; September 2015',
+    horizonUrl: 'https://horizon.stellar.org',
+    explorerUrl: 'https://stellar.expert/explorer/public',
+    explorerTxPath: 'https://stellar.expert/explorer/public/tx',
+    explorerAccountPath: 'https://stellar.expert/explorer/public/account',
+  },
+};
+
+// ─── Resolved config ─────────────────────────────────────────────────────────
+
+function resolveStellarConfig(): StellarNetworkConfig {
+  const network = getEnv('NEXT_PUBLIC_STELLAR_NETWORK') as StellarNetworkId;
+  const preset = NETWORK_PRESETS[network] ?? NETWORK_PRESETS.testnet;
+
+  // Allow env-var overrides for custom deployments
+  const horizonOverride = getEnv('NEXT_PUBLIC_HORIZON_URL');
+  const explorerOverride = getEnv('NEXT_PUBLIC_EXPLORER_URL');
+
+  return {
+    ...preset,
+    horizonUrl: horizonOverride || preset.horizonUrl,
+    explorerUrl: explorerOverride || preset.explorerUrl,
+    explorerTxPath: explorerOverride
+      ? `${explorerOverride}/tx`
+      : preset.explorerTxPath,
+    explorerAccountPath: explorerOverride
+      ? `${explorerOverride}/account`
+      : preset.explorerAccountPath,
+  };
+}
+
+/** Resolved Stellar network settings (read once, cached). */
+export const stellarConfig: StellarNetworkConfig = resolveStellarConfig();


### PR DESCRIPTION
Closes #107

Right now config values (API URLs, network settings, polling intervals, etc.) are scattered across the codebase as hardcoded strings and magic numbers. This PR pulls all of that into `src/config/` so there's one place to look and one place to change.

## What's in here

**`src/config/env.ts`** — schema for env vars with defaults + a `validateEnv()` you can call at startup to catch missing vars early. `getEnv()` gives typed access.

**`src/config/stellar.ts`** — testnet and mainnet presets (horizon URL, explorer URL, passphrase). Reads `NEXT_PUBLIC_STELLAR_NETWORK` to pick the right one. You can also override horizon/explorer URLs via env vars for custom deployments.

**`src/config/api.ts`** — API base URL, timeout, retries, wallet store key. Reads from env with sensible defaults.

**`src/config/constants.ts`** — all the magic numbers that were sprinkled around: `NETWORK_POLL_INTERVAL` (5s), `BALANCE_POLL_INTERVAL` (30s), `FILTER_DEBOUNCE_DELAY` (300ms), `COPY_FEEDBACK_TIMEOUT` (2s), storage keys, premium/deductible defaults, `FREIGHTER_CHUNK_SIZE`, etc.

**`src/config/index.ts`** — barrel export. Also exposes a unified `config` object if you want everything in one place.

**`.env.example`** — documents all the env vars with comments. Had to change `.env*` → `.env` in `.gitignore` so this file could actually be tracked.

## How to use it

```typescript
import { config } from '@/config';
import { NETWORK_POLL_INTERVAL, COPY_FEEDBACK_TIMEOUT } from '@/config';

config.stellar.horizonUrl   // picks testnet or mainnet based on env
config.api.timeout          // 30000
config.app.isDev            // true in dev

// instead of magic numbers
setInterval(poll, NETWORK_POLL_INTERVAL);   // was: 5000
setTimeout(clear, COPY_FEEDBACK_TIMEOUT);   // was: 2000
```

## Notes

- No new dependencies — just TypeScript
- Purely additive, nothing existing was modified (except the `.gitignore` tweak)
- Defaults are set so everything works without a `.env` file in dev
- Falls back to testnet if the network env var has an unknown value
- 45 tests across 5 suites, all passing
- `npx tsc --noEmit` is clean
