### PR TITLE
fix: migrate bundler config to Turbopack for Next.js 16 (closes #158)

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,14 @@ npm run test:watch
 npm run build
 ```
 
+> **Build system:** This project uses **Turbopack**, the default bundler in
+> Next.js 16, for both `next dev` and `next build`. No custom webpack
+> configuration is required — production chunk splitting is handled
+> automatically by Turbopack. Turbopack is opted into explicitly via the
+> `turbopack: {}` block in [`next.config.ts`](./next.config.ts). If you ever
+> need to fall back to webpack, add the `--webpack` flag to the `dev`/`build`
+> scripts in `package.json`.
+
 ### Linting
 
 ```bash

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,35 +4,15 @@ const nextConfig: NextConfig = {
   experimental: {
     optimizePackageImports: ["lucide-react", "@stellar/stellar-sdk"],
   },
-  webpack: (config, { isServer, dev }) => {
-    if (!isServer && !dev) {
-      config.optimization = {
-        ...config.optimization,
-        splitChunks: {
-          ...config.optimization?.splitChunks,
-          chunks: "all",
-          cacheGroups: {
-            ...config.optimization?.splitChunks?.cacheGroups,
-            vendor: {
-              test: /[\\/]node_modules[\\/]/,
-              name: "vendors",
-              priority: 20,
-              chunks: "all",
-            },
-            common: {
-              name: "common",
-              minChunks: 2,
-              priority: 10,
-              reuseExistingChunk: true,
-              chunks: "all",
-            },
-          },
-        },
-      };
-    }
-
-    return config;
-  },
+  // As of Next.js 16, Turbopack is the default bundler for `next dev` and
+  // `next build`. The previous custom webpack `splitChunks` configuration was
+  // only used to tune vendor/common chunk splitting for production builds —
+  // behaviour that Turbopack handles automatically with its own optimized
+  // chunking strategy. The webpack config has therefore been removed to resolve
+  // the Turbopack/webpack mismatch build error. This empty `turbopack` block
+  // opts into Turbopack explicitly; add options here if custom bundling is
+  // needed in the future.
+  turbopack: {},
 };
 
 export default nextConfig;

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * React Error Boundary Component
  * Catches JavaScript errors anywhere in child component tree,


### PR DESCRIPTION
## Summary

Closes #158 

Resolves the Turbopack/webpack configuration mismatch introduced by Next.js 16
Next.js 16 enables Turbopack by default for both `next dev` and
`next build`, which errored on the project's legacy webpack config that had no
corresponding `turbopack` config:

> ERROR: This build is using Turbopack, with a `webpack` config and no `turbopack` config.

## Approach — Option A (Migrate to Turbopack)

The only thing the old webpack config did was tune production `splitChunks`
(vendor/common chunk splitting) — behaviour Turbopack handles automatically and
more efficiently. So the webpack config was removed rather than reimplemented.

- **Removed** the custom `webpack: () => {}` chunk-splitting block from `next.config.ts`.
- **Added** an explicit `turbopack: {}` block to opt into Turbopack and silence the mismatch.
- **Kept** `experimental.optimizePackageImports` (fully compatible with Turbopack).
- **Added** the required `"use client"` directive to `ErrorBoundary.tsx` (a class
  component) that Turbopack flagged during the same build.
- **Documented** the build system in `README.md`, including the `--webpack` fallback path.

## Verification

- `npm run build` no longer produces the Turbopack/webpack mismatch error.
- Turbopack compiles successfully (`✓ Compiled successfully`).
- No functionality lost — chunk splitting is now handled by Turbopack's defaults.

## Note on scope

The build also surfaces **pre-existing, unrelated** TypeScript errors (e.g.
`src/types/proposal.ts` is an empty file with no exports). These exist on `main`
independent of the bundler and are out of scope for this issue — they should be
tracked separately.

Closes #158
