### PR TITLE
fix: secure session persistence and freighter validation

### DIFF
--- a/src/components/__tests__/auth-persistence.test.tsx
+++ b/src/components/__tests__/auth-persistence.test.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { AuthProvider } from '../auth-provider-enhanced';
+import { secureStorage } from '@/lib/security';
+import { isConnected } from '@stellar/freighter-api';
+import { useWalletStore } from '@/store';
+
+// Mock dependencies
+jest.mock('@/lib/security', () => ({
+  secureStorage: {
+    getItem: jest.fn(),
+    setItem: jest.fn(),
+    removeItem: jest.fn(),
+  },
+}));
+
+jest.mock('@stellar/freighter-api', () => ({
+  isConnected: jest.fn(),
+}));
+
+// Mock the wallet store
+jest.mock('@/store', () => {
+  const setSessionMock = jest.fn();
+  const signOutMock = jest.fn();
+  return {
+    useWalletStore: Object.assign(
+      jest.fn(() => ({
+        setSession: setSessionMock,
+        signOut: signOutMock,
+      })),
+      {
+        getState: jest.fn(() => ({
+          isAddressRegistered: jest.fn(),
+          registerAddress: jest.fn(),
+          getRegisteredUser: jest.fn(),
+        })),
+      }
+    ),
+  };
+});
+
+// Mock useWallet
+jest.mock('@/hooks/useWallet', () => ({
+  useWallet: jest.fn(() => ({
+    session: null,
+    disconnect: jest.fn(),
+  })),
+}));
+
+describe('AuthProvider Persistence', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Reset document cookie
+    document.cookie = '';
+  });
+
+  it('restores valid unexpired session if Freighter is connected', async () => {
+    const validSession = {
+      address: 'GABC...',
+      expiresAt: Date.now() + 100000,
+    };
+    
+    (secureStorage.getItem as jest.Mock).mockReturnValue(JSON.stringify(validSession));
+    (isConnected as jest.Mock).mockResolvedValue({ isConnected: true });
+
+    render(<AuthProvider><div>App</div></AuthProvider>);
+
+    await waitFor(() => {
+      expect(secureStorage.getItem).toHaveBeenCalledWith('wallet_session');
+      expect(isConnected).toHaveBeenCalled();
+      const { setSession } = useWalletStore();
+      expect(setSession).toHaveBeenCalledWith(validSession);
+    });
+  });
+
+  it('clears session and signs out if Freighter is not connected', async () => {
+    const validSession = {
+      address: 'GABC...',
+      expiresAt: Date.now() + 100000,
+    };
+    
+    (secureStorage.getItem as jest.Mock).mockReturnValue(JSON.stringify(validSession));
+    (isConnected as jest.Mock).mockResolvedValue({ isConnected: false });
+
+    render(<AuthProvider><div>App</div></AuthProvider>);
+
+    await waitFor(() => {
+      expect(isConnected).toHaveBeenCalled();
+      expect(secureStorage.removeItem).toHaveBeenCalledWith('wallet_session');
+      const { signOut } = useWalletStore();
+      expect(signOut).toHaveBeenCalled();
+    });
+  });
+
+  it('clears session and signs out if session is expired', async () => {
+    const expiredSession = {
+      address: 'GABC...',
+      expiresAt: Date.now() - 100000, // Expired
+    };
+    
+    (secureStorage.getItem as jest.Mock).mockReturnValue(JSON.stringify(expiredSession));
+
+    render(<AuthProvider><div>App</div></AuthProvider>);
+
+    await waitFor(() => {
+      expect(isConnected).not.toHaveBeenCalled();
+      expect(secureStorage.removeItem).toHaveBeenCalledWith('wallet_session');
+      const { signOut } = useWalletStore();
+      expect(signOut).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/auth-provider-enhanced.tsx
+++ b/src/components/auth-provider-enhanced.tsx
@@ -3,6 +3,9 @@
 import React, { createContext, useContext, useEffect, useMemo } from "react";
 import { useWallet } from "@/hooks/useWallet";
 import { AuthSession, RegisteredUser } from "@/store/types";
+import { secureStorage } from "@/lib/security";
+import { isConnected } from "@stellar/freighter-api";
+import { useWalletStore } from "@/store";
 
 // Maintain backward compatibility with existing AuthContext interface
 type AuthContextValue = {
@@ -22,41 +25,84 @@ const AuthContext = createContext<AuthContextValue | null>(null);
  */
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const wallet = useWallet();
+  const { setSession, signOut } = useWalletStore(); // Get from store directly
+  const [isInitializing, setIsInitializing] = React.useState(true);
 
-  // Sync with cookies for middleware access (maintain existing behavior)
+  // Initialize session from secure storage
   useEffect(() => {
+    const restoreSession = async () => {
+      try {
+        const stored = secureStorage.getItem("wallet_session");
+        if (stored) {
+          const session = JSON.parse(stored) as AuthSession;
+          
+          // Check expiry
+          if (session.expiresAt && session.expiresAt > Date.now()) {
+            // Validate with Freighter
+            const connected = await isConnected();
+            if (connected.isConnected) {
+              setSession(session);
+            } else {
+              // Not connected to freighter, clear session
+              secureStorage.removeItem("wallet_session");
+              signOut();
+            }
+          } else {
+            // Expired
+            secureStorage.removeItem("wallet_session");
+            signOut();
+          }
+        }
+      } catch (e) {
+        console.error("Failed to restore session:", e);
+        secureStorage.removeItem("wallet_session");
+      } finally {
+        setIsInitializing(false);
+      }
+    };
+
+    restoreSession();
+  }, [setSession, signOut]);
+
+  // Sync with cookies and secure storage
+  useEffect(() => {
+    if (isInitializing) return; // Don't persist during initialization
+    
     if (wallet.session) {
       // Set session cookie for middleware
       document.cookie = `stellar_insured_session=${JSON.stringify(wallet.session)}; path=/; max-age=${7 * 24 * 60 * 60}; samesite=strict`;
+      // Persist to local storage securely
+      secureStorage.setItem("wallet_session", JSON.stringify(wallet.session));
     } else {
-      // Clear session cookie
+      // Clear session cookie and storage
       document.cookie = 'stellar_insured_session=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+      secureStorage.removeItem("wallet_session");
     }
-  }, [wallet.session]);
+  }, [wallet.session, isInitializing]);
 
   // Create backward-compatible context value
   const contextValue = useMemo<AuthContextValue>(() => ({
     session: wallet.session,
     setSession: (session) => {
       if (session) {
-        // Use the store's setSession method directly
-        wallet.setSession(session);
+        setSession(session);
       } else {
         wallet.disconnect();
       }
     },
     signOut: wallet.disconnect,
-    isAddressRegistered: wallet.isAddressRegistered,
-    registerAddress: wallet.registerAddress,
-    getRegisteredUser: wallet.getRegisteredUser,
+    isAddressRegistered: useWalletStore.getState().isAddressRegistered,
+    registerAddress: useWalletStore.getState().registerAddress,
+    getRegisteredUser: useWalletStore.getState().getRegisteredUser,
   }), [
     wallet.session,
-    wallet.setSession,
+    setSession,
     wallet.disconnect,
-    wallet.isAddressRegistered,
-    wallet.registerAddress,
-    wallet.getRegisteredUser,
   ]);
+
+  if (isInitializing) {
+    return null; // Or a proper loading spinner if preferred, but usually null avoids hydration mismatch
+  }
 
   return (
     <AuthContext.Provider value={contextValue}>

--- a/src/store/walletStore.ts
+++ b/src/store/walletStore.ts
@@ -100,7 +100,6 @@ export const useWalletStore = create<WalletState>()(
       {
         name: 'wallet-store',
         partialize: (state) => ({
-          session: state.session,
           registeredUsers: state.registeredUsers,
         }),
       }


### PR DESCRIPTION
## Description

This pull request resolves the issue where wallet connection state was lost on page refresh. It implements secure, encrypted persistence of the wallet session data to local storage and validates it against the Freighter API upon application reload.

Closes #151 

## Changes Made
- **Centralized Session Hydration**: Refactored `AuthProvider` (`src/components/auth-provider-enhanced.tsx`) to orchestrate session persistence using `secureStorage` to ensure AES-encrypted data safety in the browser.
- **Freighter Validation**: Added logic that runs on component mount to retrieve the encrypted session, verify its `expiresAt` timestamp, and ping `isConnected()` from `@stellar/freighter-api`. The session is only fully restored if the wallet confirms the connection.
- **Graceful Fallbacks**: If the connection state is invalid, the extension is locked, or the session expired, the persisted data is wiped, and `signOut()` is cleanly dispatched to reset the store and cookies.
- **Duplicate Storage Cleanup**: Removed `session` from the Zustand `persist` middleware's `partialize` map in `src/store/walletStore.ts`. This ensures no plain-text versions of the session remain locally.
- **Integration Tests**: Added `src/__tests__/auth-persistence.test.tsx` which fully validates restoration, un-connected teardown, and expired session paths using mocked Freighter API and store boundaries.

## Validation
- ✅ Verified session is retained perfectly across forced page reloads.
- ✅ Verified session cleanly drops and requests re-auth if Freighter locks.
- ✅ Automated integration tests for `AuthProvider` are passing natively.
